### PR TITLE
Update fix GoTrueException naming update from their version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.0.1-dev.2
+
+- fix: add github actions and fix errors in example
+- fix: refactor SocialProviders by using Dart 2.17 enhanced enum
+- chore: remove flutter-plugins auto generated files from version control
+- fix: update social sign in button text
+- fix: Replace `GotrueError` with `GoTrueException`
+- fix: update supabase_flutter to v1.0.0-dev.3
+
 ## 0.0.1-dev.1
 
 - Initial developer preview release. 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -384,7 +384,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.1-dev.1"
+    version: "0.0.1-dev.2"
   supabase_flutter:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -162,7 +162,7 @@ packages:
       name: gotrue
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0-dev.1"
+    version: "1.0.0-dev.2"
   hive:
     dependency: transitive
     description:
@@ -316,7 +316,7 @@ packages:
       name: postgrest
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0-dev.1"
+    version: "1.0.0-dev.2"
   process:
     dependency: transitive
     description:
@@ -356,7 +356,7 @@ packages:
       name: storage_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0-dev.1"
+    version: "1.0.0-dev.3"
   stream_channel:
     dependency: transitive
     description:
@@ -377,7 +377,7 @@ packages:
       name: supabase
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0-dev.2"
+    version: "1.0.0-dev.3"
   supabase_auth_ui:
     dependency: "direct main"
     description:
@@ -391,7 +391,7 @@ packages:
       name: supabase_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0-dev.1"
+    version: "1.0.0-dev.3"
   term_glyph:
     dependency: transitive
     description:

--- a/lib/src/screens/supa_email_auth.dart
+++ b/lib/src/screens/supa_email_auth.dart
@@ -106,7 +106,7 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                   );
                   if (!mounted) return;
                   Navigator.popAndPushNamed(context, widget.redirectUrl ?? '');
-                } on GotrueError catch (error) {
+                } on GoTrueException catch (error) {
                   await showDialog(
                     context: context,
                     builder: (BuildContext context) {
@@ -148,7 +148,7 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                   );
                   if (!mounted) return;
                   Navigator.popAndPushNamed(context, widget.redirectUrl ?? '');
-                } on GotrueError catch (error) {
+                } on GoTrueException catch (error) {
                   await showDialog(
                     context: context,
                     builder: (BuildContext context) {

--- a/lib/src/screens/supa_magic_auth.dart
+++ b/lib/src/screens/supa_magic_auth.dart
@@ -79,7 +79,7 @@ class _SupaMagicAuthState extends State<SupaMagicAuth> {
                 );
                 if (!mounted) return;
                 Navigator.popAndPushNamed(context, widget.redirectUrl ?? '');
-              } on GotrueError catch (error) {
+              } on GoTrueException catch (error) {
                 await showDialog(
                   context: context,
                   builder: (BuildContext context) {

--- a/lib/src/screens/supa_reset_password.dart
+++ b/lib/src/screens/supa_reset_password.dart
@@ -80,7 +80,7 @@ class _SupaResetPasswordState extends State<SupaResetPassword> {
                 );
                 if (!mounted) return;
                 Navigator.popAndPushNamed(context, widget.redirectUrl ?? '');
-              } on GotrueError catch (error) {
+              } on GoTrueException catch (error) {
                 await showDialog(
                   context: context,
                   builder: (BuildContext context) {

--- a/lib/src/screens/supa_send_email.dart
+++ b/lib/src/screens/supa_send_email.dart
@@ -80,7 +80,7 @@ class _SupaSendEmailState extends State<SupaSendEmail> {
                 );
                 if (!mounted) return;
                 Navigator.popAndPushNamed(context, widget.redirectUrl ?? '');
-              } on GotrueError catch (error) {
+              } on GoTrueException catch (error) {
                 await showDialog(
                   context: context,
                   builder: (BuildContext context) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  supabase_flutter: ^1.0.0-dev.1
+  supabase_flutter: ^1.0.0-dev.3
   email_validator: ^2.0.1
   font_awesome_flutter: ^9.0.0-nullsafety
   

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supabase_auth_ui
 description: UI library to implement auth forms using Supabase and Flutter
-version: 0.0.1-dev.1
+version: 0.0.1-dev.2
 homepage: https://supabase.com
 repository: 'https://github.com/supabase-community/flutter-auth-ui'
 


### PR DESCRIPTION
I was trying to use this against the latest flutter dev library and there was a naming conflict on the GoTrue exception class name. They changed it with the version bump that the dev3 version of the supabase flutter library uses compared to the dev1 version that this was originally written against.