### PR TITLE
fix: phone auth

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:example/phone_sign_up.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:supabase_auth_ui/supabase_auth_ui.dart';
@@ -8,7 +9,7 @@ import './sign_in.dart';
 import './magic_link.dart';
 import './forgot_password.dart';
 import './update_password.dart';
-import './phone_auth.dart';
+import 'phone_sign_in.dart';
 import './verify_phone.dart';
 
 void main() async {
@@ -43,7 +44,8 @@ class MyApp extends StatelessWidget {
         '/magic_link': (context) => const MagicLink(),
         '/forgot_password': (context) => const ForgotPassword(),
         '/update_password': (context) => const UpdatePassword(),
-        '/phone_auth': (context) => const PhoneAuth(),
+        '/phone_sign_in': (context) => const PhoneSignIn(),
+        '/phone_sign_up': (context) => const PhoneSignUp(),
         '/verify_phone': (context) => const VerifyPhone(),
         '/home': (context) => const Home(),
       },

--- a/example/lib/phone_sign_in.dart
+++ b/example/lib/phone_sign_in.dart
@@ -20,11 +20,11 @@ class PhoneSignIn extends StatelessWidget {
             ),
             TextButton(
               child: const Text(
-                'Already have an account? Sign In',
+                'Don\'t have an account? Sign Up',
                 style: TextStyle(fontWeight: FontWeight.bold),
               ),
               onPressed: () {
-                Navigator.pushNamed(context, '/sign_in');
+                Navigator.pushNamed(context, '/');
               },
             ),
           ],

--- a/example/lib/phone_sign_in.dart
+++ b/example/lib/phone_sign_in.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:supabase_auth_ui/supabase_auth_ui.dart';
+
+import 'constants.dart';
+
+class PhoneSignIn extends StatelessWidget {
+  const PhoneSignIn({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: appBar,
+      body: Padding(
+        padding: const EdgeInsets.all(24.0),
+        child: Column(
+          children: [
+            const SupaPhoneAuth(
+              phoneAuthAction: PhoneAuthAction.signIn,
+              redirectUrl: '/home',
+            ),
+            TextButton(
+              child: const Text(
+                'Already have an account? Sign In',
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
+              onPressed: () {
+                Navigator.pushNamed(context, '/sign_in');
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/phone_sign_up.dart
+++ b/example/lib/phone_sign_up.dart
@@ -3,8 +3,8 @@ import 'package:supabase_auth_ui/supabase_auth_ui.dart';
 
 import 'constants.dart';
 
-class PhoneAuth extends StatelessWidget {
-  const PhoneAuth({Key? key}) : super(key: key);
+class PhoneSignUp extends StatelessWidget {
+  const PhoneSignUp({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -14,7 +14,10 @@ class PhoneAuth extends StatelessWidget {
         padding: const EdgeInsets.all(24.0),
         child: Column(
           children: [
-            const SupaPhoneAuth(redirectUrl: '/verify_phone'),
+            const SupaPhoneAuth(
+              phoneAuthAction: PhoneAuthAction.signUp,
+              redirectUrl: '/verify_phone',
+            ),
             TextButton(
               child: const Text(
                 'Already have an account? Sign In',

--- a/example/lib/sign_in.dart
+++ b/example/lib/sign_in.dart
@@ -41,6 +41,10 @@ class SignIn extends StatelessWidget {
           signInBtn(context, Icons.email, 'Sign in with Magic Link', () {
             Navigator.popAndPushNamed(context, '/magic_link');
           }),
+          spacer,
+          signInBtn(context, Icons.phone, 'Sign in with Phone', () {
+            Navigator.popAndPushNamed(context, '/phone_sign_in');
+          }),
         ],
       ),
     );

--- a/example/lib/sign_up.dart
+++ b/example/lib/sign_up.dart
@@ -35,8 +35,8 @@ class SignUp extends StatelessWidget {
             Navigator.popAndPushNamed(context, '/magic_link');
           }),
           spacer,
-          signInBtn(context, Icons.phone, 'Sign in with Phone', () {
-            Navigator.popAndPushNamed(context, '/phone_auth');
+          signInBtn(context, Icons.phone, 'Sign up with Phone', () {
+            Navigator.popAndPushNamed(context, '/phone_sign_up');
           }),
           spacer,
           const SupaSocialsAuth(

--- a/lib/src/screens/supa_email_auth.dart
+++ b/lib/src/screens/supa_email_auth.dart
@@ -33,7 +33,7 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
 
   @override
   Widget build(BuildContext context) {
-    final signingIn = widget.authAction == AuthAction.signIn;
+    final isSigningIn = widget.authAction == AuthAction.signIn;
 
     return Form(
       autovalidateMode: AutovalidateMode.onUserInteraction,
@@ -74,14 +74,14 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
           spacer(16),
           ElevatedButton(
             child: Text(
-              signingIn ? 'Sign In' : 'Sign Up',
+              isSigningIn ? 'Sign In' : 'Sign Up',
               style: const TextStyle(fontWeight: FontWeight.bold),
             ),
             onPressed: () async {
               if (!_formKey.currentState!.validate()) {
                 return;
               }
-              if (signingIn) {
+              if (isSigningIn) {
                 try {
                   await _supaAuth.signInExistingUser(
                       _email.text, _password.text);

--- a/lib/src/screens/supa_phone_auth.dart
+++ b/lib/src/screens/supa_phone_auth.dart
@@ -3,10 +3,15 @@ import 'package:supabase_auth_ui/src/utils/constants.dart';
 import 'package:supabase_auth_ui/src/utils/supabase_auth_ui.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+enum PhoneAuthAction { signIn, signUp }
+
 class SupaPhoneAuth extends StatefulWidget {
+  final PhoneAuthAction phoneAuthAction;
   final String redirectUrl;
 
-  const SupaPhoneAuth({Key? key, required this.redirectUrl}) : super(key: key);
+  const SupaPhoneAuth(
+      {Key? key, required this.phoneAuthAction, required this.redirectUrl})
+      : super(key: key);
 
   @override
   State<SupaPhoneAuth> createState() => _SupaPhoneAuthState();
@@ -33,6 +38,7 @@ class _SupaPhoneAuthState extends State<SupaPhoneAuth> {
 
   @override
   Widget build(BuildContext context) {
+    final signingIn = widget.phoneAuthAction == PhoneAuthAction.signIn;
     return Form(
       autovalidateMode: AutovalidateMode.onUserInteraction,
       key: _formKey,
@@ -69,27 +75,44 @@ class _SupaPhoneAuthState extends State<SupaPhoneAuth> {
           ),
           spacer(16),
           ElevatedButton(
-            child: const Text(
-              'Sign Up',
-              style: TextStyle(fontWeight: FontWeight.bold),
+            child: Text(
+              signingIn ? 'Sign In' : 'Sign Up',
+              style: const TextStyle(fontWeight: FontWeight.bold),
             ),
             onPressed: () async {
               if (!_formKey.currentState!.validate()) {
                 return;
               }
-
-              try {
-                await supaAuth.signInUserWithPhone(_phone.text, _password.text);
-                if (!mounted) return;
-                successAlert;
-                if (mounted) {
-                  Navigator.popAndPushNamed(context, widget.redirectUrl,
-                      arguments: {"phone": _phone.text});
+              if (signingIn) {
+                try {
+                  await supaAuth.signInUserWithPhone(
+                      _phone.text, _password.text);
+                  if (!mounted) return;
+                  successAlert;
+                  if (mounted) {
+                    Navigator.popAndPushNamed(context, widget.redirectUrl,
+                        arguments: {"phone": _phone.text});
+                  }
+                } on GoTrueException catch (error) {
+                  await warningAlert(context, error.message);
+                } catch (error) {
+                  await warningAlert(context, 'Unexpected error has occured');
                 }
-              } on GoTrueException catch (error) {
-                await warningAlert(context, error.message);
-              } catch (error) {
-                await warningAlert(context, 'Unexpected error has occured');
+              } else {
+                try {
+                  await supaAuth.createNewPhoneUser(
+                      _phone.text, _password.text);
+                  if (!mounted) return;
+                  successAlert;
+                  if (mounted) {
+                    Navigator.popAndPushNamed(context, widget.redirectUrl,
+                        arguments: {"phone": _phone.text});
+                  }
+                } on GoTrueException catch (error) {
+                  await warningAlert(context, error.message);
+                } catch (error) {
+                  await warningAlert(context, 'Unexpected error has occured');
+                }
               }
 
               setState(() {

--- a/lib/src/screens/supa_phone_auth.dart
+++ b/lib/src/screens/supa_phone_auth.dart
@@ -88,7 +88,7 @@ class _SupaPhoneAuthState extends State<SupaPhoneAuth> {
                   await supaAuth.signInUserWithPhone(
                       _phone.text, _password.text);
                   if (!mounted) return;
-                  successAlert;
+                  await successAlert(context);
                   if (mounted) {
                     Navigator.popAndPushNamed(context, widget.redirectUrl,
                         arguments: {"phone": _phone.text});
@@ -103,7 +103,7 @@ class _SupaPhoneAuthState extends State<SupaPhoneAuth> {
                   await supaAuth.createNewPhoneUser(
                       _phone.text, _password.text);
                   if (!mounted) return;
-                  successAlert;
+                  await successAlert(context);
                   if (mounted) {
                     Navigator.popAndPushNamed(context, widget.redirectUrl,
                         arguments: {"phone": _phone.text});

--- a/lib/src/screens/supa_phone_auth.dart
+++ b/lib/src/screens/supa_phone_auth.dart
@@ -38,7 +38,7 @@ class _SupaPhoneAuthState extends State<SupaPhoneAuth> {
 
   @override
   Widget build(BuildContext context) {
-    final signingIn = widget.phoneAuthAction == PhoneAuthAction.signIn;
+    final isSigningIn = widget.phoneAuthAction == PhoneAuthAction.signIn;
     return Form(
       autovalidateMode: AutovalidateMode.onUserInteraction,
       key: _formKey,

--- a/lib/src/screens/supa_phone_auth.dart
+++ b/lib/src/screens/supa_phone_auth.dart
@@ -76,14 +76,14 @@ class _SupaPhoneAuthState extends State<SupaPhoneAuth> {
           spacer(16),
           ElevatedButton(
             child: Text(
-              signingIn ? 'Sign In' : 'Sign Up',
+              isSigningIn ? 'Sign In' : 'Sign Up',
               style: const TextStyle(fontWeight: FontWeight.bold),
             ),
             onPressed: () async {
               if (!_formKey.currentState!.validate()) {
                 return;
               }
-              if (signingIn) {
+              if (isSigningIn) {
                 try {
                   await supaAuth.signInUserWithPhone(
                       _phone.text, _password.text);


### PR DESCRIPTION
Draft one - to include both phone sign ups and sign ins. the first only had sign ins and was calling the wrong method on sign up. 

Also, i noticed within the supabase_flutter lib in phone auth sign up - it throws an error if res.data is empty. But res.data would be empty till verification. This blocks the flow coz an error will always be thrown and yet the verification code was being sent to my phone.
<img width="638" alt="Screenshot 2022-08-14 at 14 10 57" src="https://user-images.githubusercontent.com/67555014/184534130-33a08a2a-955b-4a60-b62e-275b0a6f58ad.png">

 