### PR TITLE
Support a more elaborated authentication workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 <p float="left">
 <img src="https://github.com/supabase/supabase/blob/master/packages/common/assets/images/supabase-logo-wordmark--dark.png"  width="60%" height="50%" />
 </p>
-A simple library of predefined widgets to easily and quickly create auth components using Flutter and Supabase. 
+A simple library of predefined widgets to easily and quickly create auth components using Flutter and Supabase.
 
-> :warning: **Developer Preview**: This is a developer preview and there maybe some breaking changes until we release v0.0.1. 
+> :warning: **Developer Preview**: This is a developer preview and there maybe some breaking changes until we release v0.0.1.
 
 ![Supabase Auth UI](https://raw.githubusercontent.com/supabase-community/flutter-auth-ui/main/assets/supabase_auth_ui.png "UI Sample")
 
@@ -16,12 +16,16 @@ Use a `SupaEmailAuth` widget to create an email and password signin/ signup form
 // Create a Signup form
 SupaEmailAuth(
     authAction: AuthAction.signUp,
-    redirectUrl: '/home',
+    redirectUrl: kIsWeb
+          ? null
+          : 'io.supabase.flutter://reset-callback/'
 ),
 // Create a Signin form
 SupaEmailAuth(
     authAction: AuthAction.signIn,
-    redirectUrl: '/home',
+    redirectUrl: kIsWeb
+          ? null
+          : 'io.supabase.flutter://reset-callback/'
 ),
 ```
 
@@ -30,7 +34,9 @@ SupaEmailAuth(
 Use `SupaMagicAuth` widget to create a magic link signIn form.
 
 ```dart
-SupaMagicAuth()
+SupaMagicAuth(redirectUrl: kIsWeb
+          ? null
+          : 'io.supabase.flutter://reset-callback/')
 ```
 
 ## Reset password
@@ -38,7 +44,9 @@ SupaMagicAuth()
 Use `SupaResetPassword` to create a password reset form.
 
 ```dart
-SupaResetPassword(accessToken: session.accessToken)
+SupaResetPassword(accessToken: session.accessToken, redirectUrl: kIsWeb
+          ? null
+          : 'io.supabase.flutter://reset-callback/')
 ```
 
 ## Social Auth
@@ -52,5 +60,8 @@ SupaSocialsAuth(
     SocialProviders.google,
     ],
     colored: true,
+    redirectUrl: kIsWeb
+          ? null
+          : 'io.supabase.flutter://reset-callback/'
 )
 ```

--- a/README.md
+++ b/README.md
@@ -70,8 +70,10 @@ SupaSocialsAuth(
 
 For `SupaSocialsAuth`, `SupaEmailAuth`, `SupaResetPassword` and `SupaMagicAuth` it is possible to specify a ```onSuccess``` and a ```onError``` callback.
 
+Note: Defining ```onSuccess``` disable the default success alert message.
+
 ```onSuccess``` will be called when the *Supabase* operation succeeds with the object returned from *GoTrue*.
-```onError``` will be called when the *Supabase* operation fails because of *GoTrue* with a *GotrueException* as a parameter.
+```onError``` will be called when the *Supabase* operation fails because of *GoTrue* with a *GoTrueException* as a parameter.
 
 ```dart
 SupaEmailAuth(
@@ -79,14 +81,14 @@ SupaEmailAuth(
     redirectUrl: kIsWeb
           ? null
           : 'io.supabase.flutter://reset-callback/',
-    onSuccess: (response) {
+    onSuccess: (response) { // default success alert is disabled because we specified a ```onSuccess``` callback
         if (response.user != null) {
-            // navigate('home');
+            // do something, for example: navigate('home');
         }
     },
     onError: (error) {
         if (error.message == "Email not confirmed") {
-            // navigate("wait_for_email");
+            // do something, for example: navigate("wait_for_email");
             return true; // we handled the error
         }
         return false; // false to let the library display an error message.

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ SupaEmailAuth(
     redirectUrl: kIsWeb
           ? null
           : 'io.supabase.flutter://reset-callback/'
-),
+)
 // Create a Signin form
 SupaEmailAuth(
     authAction: AuthAction.signIn,
     redirectUrl: kIsWeb
           ? null
           : 'io.supabase.flutter://reset-callback/'
-),
+)
 ```
 
 ## Magic Link Auth
@@ -64,4 +64,32 @@ SupaSocialsAuth(
           ? null
           : 'io.supabase.flutter://reset-callback/'
 )
+```
+
+## onSuccess / onError callbacks
+
+For `SupaSocialsAuth`, `SupaEmailAuth`, `SupaResetPassword` and `SupaMagicAuth` it is possible to specify a ```onSuccess``` and a ```onError``` callback.
+
+```onSuccess``` will be called when the *Supabase* operation succeeds with the object returned from *GoTrue*.
+```onError``` will be called when the *Supabase* operation fails because of *GoTrue* with a *GotrueException* as a parameter.
+
+```dart
+SupaEmailAuth(
+    authAction: AuthAction.signIn,
+    redirectUrl: kIsWeb
+          ? null
+          : 'io.supabase.flutter://reset-callback/',
+    onSuccess: (response) {
+        if (response.user != null) {
+            // navigate('home');
+        }
+    },
+    onError: (error) {
+        if (error.message == "Email not confirmed") {
+            // navigate("wait_for_email");
+            return true; // we handled the error
+        }
+        return false; // false to let the library display an error message.
+    },
+);
 ```

--- a/example/macos/Runner/DebugProfile.entitlements
+++ b/example/macos/Runner/DebugProfile.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>

--- a/example/macos/Runner/Release.entitlements
+++ b/example/macos/Runner/Release.entitlements
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
-</dict>
+	<dict>
+		<key>com.apple.security.app-sandbox</key>
+		<true />
+		<key>com.apple.security.network.client</key>
+		<true />
+	</dict>
 </plist>

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -56,21 +56,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
@@ -98,7 +91,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   ffi:
     dependency: transitive
     description:
@@ -218,21 +211,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   mime:
     dependency: transitive
     description:
@@ -246,7 +239,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   path_provider:
     dependency: transitive
     description:
@@ -342,7 +335,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -370,7 +363,7 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   supabase:
     dependency: transitive
     description:
@@ -398,14 +391,14 @@ packages:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.12"
   typed_data:
     dependency: transitive
     description:

--- a/lib/src/screens/supa_email_auth.dart
+++ b/lib/src/screens/supa_email_auth.dart
@@ -96,12 +96,12 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                     style: const TextStyle(fontWeight: FontWeight.bold),
                   ),
             onPressed: () async {
-              setState(() {
-                isLoading = true;
-              });
               if (!_formKey.currentState!.validate()) {
                 return;
               }
+              setState(() {
+                isLoading = true;
+              });
               try {
                 if (isSigningIn == false) {
                   try {

--- a/lib/src/screens/supa_email_auth.dart
+++ b/lib/src/screens/supa_email_auth.dart
@@ -116,16 +116,16 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                 final result = await _supaAuth.signInExistingUser(
                     _email.text, _password.text);
                 widget.onSuccess?.call(result);
-                if (widget.onSuccess == null && mounted) {
-                  successAlert(context);
+                if (mounted) {
+                  successSnackBar(context, 'Successfully signed in !');
                 }
               } on GoTrueException catch (error) {
                 if (widget.onError == null ||
                     widget.onError?.call(error) == false) {
-                  await warningAlert(context, error.message);
+                  await warningSnackBar(context, error.message);
                 }
               } catch (error) {
-                await warningAlert(
+                await warningSnackBar(
                     context, 'Unexpected error has occurred: $error');
               }
               if (mounted) {

--- a/lib/src/screens/supa_email_auth.dart
+++ b/lib/src/screens/supa_email_auth.dart
@@ -60,7 +60,7 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
           TextFormField(
             validator: (value) {
               if (value == null || value.isEmpty || value.length < 6) {
-                return 'Please enter a password that is atleast 6 characters long';
+                return 'Please enter a password that is at least 6 characters long';
               }
               return null;
             },
@@ -109,7 +109,7 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                 } on GoTrueException catch (error) {
                   await warningAlert(context, error.message);
                 } catch (error) {
-                  await warningAlert(context, 'Unexpected error has occured');
+                  await warningAlert(context, 'Unexpected error has occurred');
                 }
               }
               setState(() {

--- a/lib/src/screens/supa_email_auth.dart
+++ b/lib/src/screens/supa_email_auth.dart
@@ -26,6 +26,8 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
 
   final _supaAuth = SupabaseAuthUi();
 
+  bool isLoading = false;
+
   @override
   void dispose() {
     _email.dispose();
@@ -75,11 +77,23 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
           ),
           spacer(16),
           ElevatedButton(
-            child: Text(
-              isSigningIn ? 'Sign In' : 'Sign Up',
-              style: const TextStyle(fontWeight: FontWeight.bold),
-            ),
+            child: (isLoading)
+                ? const SizedBox(
+                    height: 16,
+                    width: 16,
+                    child: CircularProgressIndicator(
+                      color: Colors.white,
+                      strokeWidth: 1.5,
+                    ),
+                  )
+                : Text(
+                    isSigningIn ? 'Sign In' : 'Sign Up',
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
             onPressed: () async {
+              setState(() {
+                isLoading = true;
+              });
               if (!_formKey.currentState!.validate()) {
                 return;
               }
@@ -87,8 +101,6 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                 try {
                   final result = await _supaAuth.signInExistingUser(
                       _email.text, _password.text);
-                  if (!mounted) return;
-                  // await successAlert(context);
                   widget.callback?.call(result);
                 } on GoTrueException catch (error) {
                   await warningAlert(context, error.message);
@@ -101,15 +113,16 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                       _email.text, _password.text,
                       redirectUrl: widget.redirectUrl);
                   widget.callback?.call(result);
-                  if (!mounted) return;
-                  setState(() {
-                    isLoading = false;
-                  });
                 } on GoTrueException catch (error) {
                   await warningAlert(context, error.message);
                 } catch (error) {
                   await warningAlert(context, 'Unexpected error has occurred');
                 }
+              }
+              if (mounted) {
+                setState(() {
+                  isLoading = false;
+                });
               }
             },
           ),

--- a/lib/src/screens/supa_email_auth.dart
+++ b/lib/src/screens/supa_email_auth.dart
@@ -108,10 +108,12 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                       _email.text, _password.text);
                   widget.onSuccess?.call(result);
                 } else {
-                  final result = await _supaAuth.createNewEmailUser(
+                  await _supaAuth.createNewEmailUser(
                       _email.text, _password.text,
                       redirectUrl: widget.redirectUrl);
-
+                  // call SignIn to support case where the user exists, or no email confirmation are needed
+                  final result = await _supaAuth.signInExistingUser(
+                      _email.text, _password.text);
                   widget.onSuccess?.call(result);
                 }
               } on GoTrueException catch (error) {

--- a/lib/src/screens/supa_email_auth.dart
+++ b/lib/src/screens/supa_email_auth.dart
@@ -108,9 +108,13 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                       _email.text, _password.text);
                   widget.onSuccess?.call(result);
                 } else {
-                  await _supaAuth.createNewEmailUser(
-                      _email.text, _password.text,
-                      redirectUrl: widget.redirectUrl);
+                  try {
+                    await _supaAuth.createNewEmailUser(
+                        _email.text, _password.text,
+                        redirectUrl: widget.redirectUrl);
+                  } on GoTrueException catch (error) {
+                    if (error.message != "User already registered") rethrow;
+                  }
                   // call SignIn to support case where the user exists, or no email confirmation are needed
                   final result = await _supaAuth.signInExistingUser(
                       _email.text, _password.text);

--- a/lib/src/screens/supa_email_auth.dart
+++ b/lib/src/screens/supa_email_auth.dart
@@ -99,7 +99,8 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
               } else {
                 try {
                   await _supaAuth.createNewEmailUser(
-                      _email.text, _password.text);
+                      _email.text, _password.text,
+                      redirectUrl: widget.redirectUrl);
                   if (!mounted) return;
                   await successAlert(context);
                   if (mounted) {

--- a/lib/src/screens/supa_email_auth.dart
+++ b/lib/src/screens/supa_email_auth.dart
@@ -127,7 +127,7 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                 }
               } catch (error) {
                 await warningAlert(
-                    context, 'Unexpected error has occurred: ${error}');
+                    context, 'Unexpected error has occurred: $error');
               }
               if (mounted) {
                 setState(() {

--- a/lib/src/screens/supa_email_auth.dart
+++ b/lib/src/screens/supa_email_auth.dart
@@ -119,6 +119,9 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                   final result = await _supaAuth.signInExistingUser(
                       _email.text, _password.text);
                   widget.onSuccess?.call(result);
+                  if (widget.onSuccess == null && mounted) {
+                    successAlert(context);
+                  }
                 }
               } on GoTrueException catch (error) {
                 if (widget.onError == null ||

--- a/lib/src/screens/supa_email_auth.dart
+++ b/lib/src/screens/supa_email_auth.dart
@@ -105,7 +105,8 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                 } on GoTrueException catch (error) {
                   await warningAlert(context, error.message);
                 } catch (error) {
-                  await warningAlert(context, 'Unexpected error has occurred');
+                  await warningAlert(
+                      context, 'Unexpected error has occurred: ${error}');
                 }
               } else {
                 try {
@@ -116,7 +117,8 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                 } on GoTrueException catch (error) {
                   await warningAlert(context, error.message);
                 } catch (error) {
-                  await warningAlert(context, 'Unexpected error has occurred');
+                  await warningAlert(
+                      context, 'Unexpected error has occurred: ${error}');
                 }
               }
               if (mounted) {

--- a/lib/src/screens/supa_email_auth.dart
+++ b/lib/src/screens/supa_email_auth.dart
@@ -103,11 +103,7 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                 return;
               }
               try {
-                if (isSigningIn) {
-                  final result = await _supaAuth.signInExistingUser(
-                      _email.text, _password.text);
-                  widget.onSuccess?.call(result);
-                } else {
+                if (isSigningIn == false) {
                   try {
                     await _supaAuth.createNewEmailUser(
                         _email.text, _password.text,
@@ -115,13 +111,13 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                   } on GoTrueException catch (error) {
                     if (error.message != "User already registered") rethrow;
                   }
-                  // call SignIn to support case where the user exists, or no email confirmation are needed
-                  final result = await _supaAuth.signInExistingUser(
-                      _email.text, _password.text);
-                  widget.onSuccess?.call(result);
-                  if (widget.onSuccess == null && mounted) {
-                    successAlert(context);
-                  }
+                }
+                // Always call SignIn to support case where the user exists, or no email confirmation are needed
+                final result = await _supaAuth.signInExistingUser(
+                    _email.text, _password.text);
+                widget.onSuccess?.call(result);
+                if (widget.onSuccess == null && mounted) {
+                  successAlert(context);
                 }
               } on GoTrueException catch (error) {
                 if (widget.onError == null ||

--- a/lib/src/screens/supa_email_auth.dart
+++ b/lib/src/screens/supa_email_auth.dart
@@ -9,8 +9,10 @@ enum AuthAction { signIn, signUp }
 class SupaEmailAuth extends StatefulWidget {
   final AuthAction authAction;
   final String? redirectUrl;
+  final void Function(GotrueSessionResponse response)? callback;
 
-  const SupaEmailAuth({Key? key, required this.authAction, this.redirectUrl})
+  const SupaEmailAuth(
+      {Key? key, required this.authAction, this.redirectUrl, this.callback})
       : super(key: key);
 
   @override
@@ -83,40 +85,32 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
               }
               if (isSigningIn) {
                 try {
-                  await _supaAuth.signInExistingUser(
+                  final result = await _supaAuth.signInExistingUser(
                       _email.text, _password.text);
                   if (!mounted) return;
-                  await successAlert(context);
-                  if (mounted) {
-                    Navigator.popAndPushNamed(
-                        context, widget.redirectUrl ?? '/');
-                  }
+                  // await successAlert(context);
+                  widget.callback?.call(result);
                 } on GoTrueException catch (error) {
                   await warningAlert(context, error.message);
                 } catch (error) {
-                  await warningAlert(context, 'Unexpected error has occured');
+                  await warningAlert(context, 'Unexpected error has occurred');
                 }
               } else {
                 try {
-                  await _supaAuth.createNewEmailUser(
+                  final result = await _supaAuth.createNewEmailUser(
                       _email.text, _password.text,
                       redirectUrl: widget.redirectUrl);
+                  widget.callback?.call(result);
                   if (!mounted) return;
-                  await successAlert(context);
-                  if (mounted) {
-                    Navigator.popAndPushNamed(
-                        context, widget.redirectUrl ?? '/');
-                  }
+                  setState(() {
+                    isLoading = false;
+                  });
                 } on GoTrueException catch (error) {
                   await warningAlert(context, error.message);
                 } catch (error) {
                   await warningAlert(context, 'Unexpected error has occurred');
                 }
               }
-              setState(() {
-                _email.text = '';
-                _password.text = '';
-              });
             },
           ),
           spacer(10),

--- a/lib/src/screens/supa_magic_auth.dart
+++ b/lib/src/screens/supa_magic_auth.dart
@@ -81,16 +81,16 @@ class _SupaMagicAuthState extends State<SupaMagicAuth> {
                     _email.text,
                     redirectUrl: widget.redirectUrl);
                 widget.onSuccess?.call(result);
-                if (widget.onSuccess == null && mounted) {
-                  successAlert(context);
+                if (mounted) {
+                  successSnackBar(context, 'Created passwordless user !');
                 }
               } on GoTrueException catch (error) {
                 if (widget.onError == null ||
                     widget.onError?.call(error) == false) {
-                  await warningAlert(context, error.message);
+                  await warningSnackBar(context, error.message);
                 }
               } catch (error) {
-                await warningAlert(
+                await warningSnackBar(
                     context, 'Unexpected error has occurred: $error');
               }
               if (mounted) {

--- a/lib/src/screens/supa_magic_auth.dart
+++ b/lib/src/screens/supa_magic_auth.dart
@@ -70,12 +70,12 @@ class _SupaMagicAuthState extends State<SupaMagicAuth> {
                     style: TextStyle(fontWeight: FontWeight.bold),
                   ),
             onPressed: () async {
-              setState(() {
-                isLoading = true;
-              });
               if (!_formKey.currentState!.validate()) {
                 return;
               }
+              setState(() {
+                isLoading = true;
+              });
               try {
                 final result = await _supaAuth.createNewPasswordlessUser(
                     _email.text,

--- a/lib/src/screens/supa_magic_auth.dart
+++ b/lib/src/screens/supa_magic_auth.dart
@@ -6,8 +6,10 @@ import 'package:supabase_auth_ui/src/utils/constants.dart';
 
 class SupaMagicAuth extends StatefulWidget {
   final String? redirectUrl;
+  final void Function(GotrueSessionResponse response)? callback;
 
-  const SupaMagicAuth({Key? key, this.redirectUrl}) : super(key: key);
+  const SupaMagicAuth({Key? key, this.redirectUrl, this.callback})
+      : super(key: key);
 
   @override
   State<SupaMagicAuth> createState() => _SupaMagicAuthState();
@@ -59,22 +61,15 @@ class _SupaMagicAuthState extends State<SupaMagicAuth> {
                 return;
               }
               try {
-                if (!mounted) return;
-                await successAlert(context);
-                if (mounted) {
-                  Navigator.popAndPushNamed(context, widget.redirectUrl ?? '');
-                }
                 final result = await _supaAuth.createNewPasswordlessUser(
                     _email.text,
                     redirectUrl: widget.redirectUrl);
+                widget.callback?.call(result);
               } on GoTrueException catch (error) {
                 await warningAlert(context, error.message);
               } catch (error) {
                 await warningAlert(context, 'Unexpected error has occurred');
               }
-              setState(() {
-                _email.text = '';
-              });
             },
           ),
           spacer(10),

--- a/lib/src/screens/supa_magic_auth.dart
+++ b/lib/src/screens/supa_magic_auth.dart
@@ -6,9 +6,11 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 class SupaMagicAuth extends StatefulWidget {
   final String? redirectUrl;
-  final void Function(GotrueSessionResponse response)? callback;
+  final void Function(GotrueSessionResponse response)? onSuccess;
+  final bool Function(GoTrueException error)? onError;
 
-  const SupaMagicAuth({Key? key, this.redirectUrl, this.callback})
+  const SupaMagicAuth(
+      {Key? key, this.redirectUrl, this.onSuccess, this.onError})
       : super(key: key);
 
   @override
@@ -78,9 +80,12 @@ class _SupaMagicAuthState extends State<SupaMagicAuth> {
                 final result = await _supaAuth.createNewPasswordlessUser(
                     _email.text,
                     redirectUrl: widget.redirectUrl);
-                widget.callback?.call(result);
+                widget.onSuccess?.call(result);
               } on GoTrueException catch (error) {
-                await warningAlert(context, error.message);
+                if (widget.onError == null ||
+                    widget.onError?.call(error) == false) {
+                  await warningAlert(context, error.message);
+                }
               } catch (error) {
                 await warningAlert(
                     context, 'Unexpected error has occurred: ${error}');

--- a/lib/src/screens/supa_magic_auth.dart
+++ b/lib/src/screens/supa_magic_auth.dart
@@ -51,7 +51,7 @@ class _SupaMagicAuthState extends State<SupaMagicAuth> {
           spacer(16),
           ElevatedButton(
             child: const Text(
-              'Sign Up with Magic Link',
+              'Continue with Magic Link',
               style: TextStyle(fontWeight: FontWeight.bold),
             ),
             onPressed: () async {

--- a/lib/src/screens/supa_magic_auth.dart
+++ b/lib/src/screens/supa_magic_auth.dart
@@ -81,6 +81,9 @@ class _SupaMagicAuthState extends State<SupaMagicAuth> {
                     _email.text,
                     redirectUrl: widget.redirectUrl);
                 widget.onSuccess?.call(result);
+                if (widget.onSuccess == null && mounted) {
+                  successAlert(context);
+                }
               } on GoTrueException catch (error) {
                 if (widget.onError == null ||
                     widget.onError?.call(error) == false) {

--- a/lib/src/screens/supa_magic_auth.dart
+++ b/lib/src/screens/supa_magic_auth.dart
@@ -88,7 +88,7 @@ class _SupaMagicAuthState extends State<SupaMagicAuth> {
                 }
               } catch (error) {
                 await warningAlert(
-                    context, 'Unexpected error has occurred: ${error}');
+                    context, 'Unexpected error has occurred: $error');
               }
               if (mounted) {
                 setState(() {

--- a/lib/src/screens/supa_magic_auth.dart
+++ b/lib/src/screens/supa_magic_auth.dart
@@ -1,8 +1,8 @@
 import 'package:email_validator/email_validator.dart';
 import 'package:flutter/material.dart';
+import 'package:supabase_auth_ui/src/utils/constants.dart';
 import 'package:supabase_auth_ui/src/utils/supabase_auth_ui.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
-import 'package:supabase_auth_ui/src/utils/constants.dart';
 
 class SupaMagicAuth extends StatefulWidget {
   final String? redirectUrl;
@@ -20,6 +20,8 @@ class _SupaMagicAuthState extends State<SupaMagicAuth> {
   final _email = TextEditingController();
 
   final _supaAuth = SupabaseAuthUi();
+
+  bool isLoading = false;
 
   @override
   void dispose() {
@@ -52,11 +54,23 @@ class _SupaMagicAuthState extends State<SupaMagicAuth> {
           ),
           spacer(16),
           ElevatedButton(
-            child: const Text(
-              'Continue with Magic Link',
-              style: TextStyle(fontWeight: FontWeight.bold),
-            ),
+            child: (isLoading)
+                ? const SizedBox(
+                    height: 16,
+                    width: 16,
+                    child: CircularProgressIndicator(
+                      color: Colors.white,
+                      strokeWidth: 1.5,
+                    ),
+                  )
+                : const Text(
+                    'Continue with magic Link',
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                  ),
             onPressed: () async {
+              setState(() {
+                isLoading = true;
+              });
               if (!_formKey.currentState!.validate()) {
                 return;
               }
@@ -69,6 +83,11 @@ class _SupaMagicAuthState extends State<SupaMagicAuth> {
                 await warningAlert(context, error.message);
               } catch (error) {
                 await warningAlert(context, 'Unexpected error has occurred');
+              }
+              if (mounted) {
+                setState(() {
+                  isLoading = false;
+                });
               }
             },
           ),

--- a/lib/src/screens/supa_magic_auth.dart
+++ b/lib/src/screens/supa_magic_auth.dart
@@ -59,12 +59,14 @@ class _SupaMagicAuthState extends State<SupaMagicAuth> {
                 return;
               }
               try {
-                await _supaAuth.createNewPasswordlessUser(_email.text);
                 if (!mounted) return;
                 await successAlert(context);
                 if (mounted) {
                   Navigator.popAndPushNamed(context, widget.redirectUrl ?? '');
                 }
+                final result = await _supaAuth.createNewPasswordlessUser(
+                    _email.text,
+                    redirectUrl: widget.redirectUrl);
               } on GoTrueException catch (error) {
                 await warningAlert(context, error.message);
               } catch (error) {

--- a/lib/src/screens/supa_magic_auth.dart
+++ b/lib/src/screens/supa_magic_auth.dart
@@ -82,7 +82,8 @@ class _SupaMagicAuthState extends State<SupaMagicAuth> {
               } on GoTrueException catch (error) {
                 await warningAlert(context, error.message);
               } catch (error) {
-                await warningAlert(context, 'Unexpected error has occurred');
+                await warningAlert(
+                    context, 'Unexpected error has occurred: ${error}');
               }
               if (mounted) {
                 setState(() {

--- a/lib/src/screens/supa_magic_auth.dart
+++ b/lib/src/screens/supa_magic_auth.dart
@@ -68,7 +68,7 @@ class _SupaMagicAuthState extends State<SupaMagicAuth> {
               } on GoTrueException catch (error) {
                 await warningAlert(context, error.message);
               } catch (error) {
-                await warningAlert(context, 'Unexpected error has occured');
+                await warningAlert(context, 'Unexpected error has occurred');
               }
               setState(() {
                 _email.text = '';

--- a/lib/src/screens/supa_phone_auth.dart
+++ b/lib/src/screens/supa_phone_auth.dart
@@ -88,15 +88,15 @@ class _SupaPhoneAuthState extends State<SupaPhoneAuth> {
                   await supaAuth.signInUserWithPhone(
                       _phone.text, _password.text);
                   if (!mounted) return;
-                  await successAlert(context);
+                  await successSnackBar(context, 'Successfully signed in !');
                   if (mounted) {
                     Navigator.popAndPushNamed(context, widget.redirectUrl,
                         arguments: {"phone": _phone.text});
                   }
                 } on GoTrueException catch (error) {
-                  await warningAlert(context, error.message);
+                  await warningSnackBar(context, error.message);
                 } catch (error) {
-                  await warningAlert(
+                  await warningSnackBar(
                       context, 'Unexpected error has occurred: $error');
                 }
               } else {
@@ -104,15 +104,15 @@ class _SupaPhoneAuthState extends State<SupaPhoneAuth> {
                   await supaAuth.createNewPhoneUser(
                       _phone.text, _password.text);
                   if (!mounted) return;
-                  await successAlert(context);
+                  await successSnackBar(context, 'Successfully created !');
                   if (mounted) {
                     Navigator.popAndPushNamed(context, widget.redirectUrl,
                         arguments: {"phone": _phone.text});
                   }
                 } on GoTrueException catch (error) {
-                  await warningAlert(context, error.message);
+                  await warningSnackBar(context, error.message);
                 } catch (error) {
-                  await warningAlert(
+                  await warningSnackBar(
                       context, 'Unexpected error has occurred: $error');
                 }
               }

--- a/lib/src/screens/supa_phone_auth.dart
+++ b/lib/src/screens/supa_phone_auth.dart
@@ -96,7 +96,8 @@ class _SupaPhoneAuthState extends State<SupaPhoneAuth> {
                 } on GoTrueException catch (error) {
                   await warningAlert(context, error.message);
                 } catch (error) {
-                  await warningAlert(context, 'Unexpected error has occurred');
+                  await warningAlert(
+                      context, 'Unexpected error has occurred: ${error}');
                 }
               } else {
                 try {
@@ -111,7 +112,8 @@ class _SupaPhoneAuthState extends State<SupaPhoneAuth> {
                 } on GoTrueException catch (error) {
                   await warningAlert(context, error.message);
                 } catch (error) {
-                  await warningAlert(context, 'Unexpected error has occurred');
+                  await warningAlert(
+                      context, 'Unexpected error has occurred: ${error}');
                 }
               }
 

--- a/lib/src/screens/supa_phone_auth.dart
+++ b/lib/src/screens/supa_phone_auth.dart
@@ -97,7 +97,7 @@ class _SupaPhoneAuthState extends State<SupaPhoneAuth> {
                   await warningAlert(context, error.message);
                 } catch (error) {
                   await warningAlert(
-                      context, 'Unexpected error has occurred: ${error}');
+                      context, 'Unexpected error has occurred: $error');
                 }
               } else {
                 try {
@@ -113,7 +113,7 @@ class _SupaPhoneAuthState extends State<SupaPhoneAuth> {
                   await warningAlert(context, error.message);
                 } catch (error) {
                   await warningAlert(
-                      context, 'Unexpected error has occurred: ${error}');
+                      context, 'Unexpected error has occurred: $error');
                 }
               }
 

--- a/lib/src/screens/supa_phone_auth.dart
+++ b/lib/src/screens/supa_phone_auth.dart
@@ -96,7 +96,7 @@ class _SupaPhoneAuthState extends State<SupaPhoneAuth> {
                 } on GoTrueException catch (error) {
                   await warningAlert(context, error.message);
                 } catch (error) {
-                  await warningAlert(context, 'Unexpected error has occured');
+                  await warningAlert(context, 'Unexpected error has occurred');
                 }
               } else {
                 try {
@@ -111,7 +111,7 @@ class _SupaPhoneAuthState extends State<SupaPhoneAuth> {
                 } on GoTrueException catch (error) {
                   await warningAlert(context, error.message);
                 } catch (error) {
-                  await warningAlert(context, 'Unexpected error has occured');
+                  await warningAlert(context, 'Unexpected error has occurred');
                 }
               }
 

--- a/lib/src/screens/supa_reset_password.dart
+++ b/lib/src/screens/supa_reset_password.dart
@@ -65,16 +65,16 @@ class _SupaResetPasswordState extends State<SupaResetPassword> {
                 final result = await _supaAuth.updateUserPassword(
                     accessToken, _password.text);
                 widget.onSuccess?.call(result);
-                if (widget.onSuccess == null && mounted) {
-                  successAlert(context);
+                if (mounted) {
+                  successSnackBar(context, 'Successfully updated password !');
                 }
               } on GoTrueException catch (error) {
                 if (widget.onError == null ||
                     widget.onError?.call(error) == false) {
-                  await warningAlert(context, error.message);
+                  await warningSnackBar(context, error.message);
                 }
               } catch (error) {
-                await warningAlert(
+                await warningSnackBar(
                     context, 'Unexpected error has occurred: $error');
               }
             },

--- a/lib/src/screens/supa_reset_password.dart
+++ b/lib/src/screens/supa_reset_password.dart
@@ -38,7 +38,7 @@ class _SupaResetPasswordState extends State<SupaResetPassword> {
           TextFormField(
             validator: (value) {
               if (value == null || value.isEmpty || value.length < 6) {
-                return 'Please enter a password that is atleast 6 characters long';
+                return 'Please enter a password that is at least 6 characters long';
               }
               return null;
             },
@@ -69,7 +69,7 @@ class _SupaResetPasswordState extends State<SupaResetPassword> {
               } on GoTrueException catch (error) {
                 await warningAlert(context, error.message);
               } catch (error) {
-                await warningAlert(context, 'Unexpected error has occured');
+                await warningAlert(context, 'Unexpected error has occurred');
               }
               setState(() {
                 _password.text = '';

--- a/lib/src/screens/supa_reset_password.dart
+++ b/lib/src/screens/supa_reset_password.dart
@@ -6,9 +6,10 @@ import 'package:supabase_auth_ui/src/utils/constants.dart';
 class SupaResetPassword extends StatefulWidget {
   final String accessToken;
   final String? redirectUrl;
+  final void Function(GotrueUserResponse response)? callback;
 
   const SupaResetPassword(
-      {Key? key, required this.accessToken, this.redirectUrl})
+      {Key? key, required this.accessToken, this.redirectUrl, this.callback})
       : super(key: key);
 
   @override
@@ -59,8 +60,9 @@ class _SupaResetPasswordState extends State<SupaResetPassword> {
                 return;
               }
               try {
-                await _supaAuth.updateUserPassword(
+                final result = await _supaAuth.updateUserPassword(
                     widget.accessToken, _password.text);
+                widget.callback?.call(result);
                 if (!mounted) return;
                 await successAlert(context);
                 if (mounted) {
@@ -71,9 +73,6 @@ class _SupaResetPasswordState extends State<SupaResetPassword> {
               } catch (error) {
                 await warningAlert(context, 'Unexpected error has occurred');
               }
-              setState(() {
-                _password.text = '';
-              });
             },
           ),
           spacer(10),

--- a/lib/src/screens/supa_reset_password.dart
+++ b/lib/src/screens/supa_reset_password.dart
@@ -4,12 +4,12 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:supabase_auth_ui/src/utils/constants.dart';
 
 class SupaResetPassword extends StatefulWidget {
-  final String accessToken;
+  final String? accessToken;
   final void Function(GotrueUserResponse response)? onSuccess;
   final bool Function(GoTrueException error)? onError;
 
   const SupaResetPassword(
-      {Key? key, required this.accessToken, this.onSuccess, this.onError})
+      {Key? key, this.accessToken, this.onSuccess, this.onError})
       : super(key: key);
 
   @override
@@ -30,6 +30,8 @@ class _SupaResetPasswordState extends State<SupaResetPassword> {
 
   @override
   Widget build(BuildContext context) {
+    final accessToken =
+        widget.accessToken ?? supaClient.auth.currentSession!.accessToken;
     return Form(
       autovalidateMode: AutovalidateMode.onUserInteraction,
       key: _formKey,
@@ -61,7 +63,7 @@ class _SupaResetPasswordState extends State<SupaResetPassword> {
               }
               try {
                 final result = await _supaAuth.updateUserPassword(
-                    widget.accessToken, _password.text);
+                    accessToken, _password.text);
                 widget.onSuccess?.call(result);
                 if (widget.onSuccess == null && mounted) {
                   successAlert(context);

--- a/lib/src/screens/supa_reset_password.dart
+++ b/lib/src/screens/supa_reset_password.dart
@@ -80,7 +80,7 @@ class _SupaResetPasswordState extends State<SupaResetPassword> {
                 }
               } catch (error) {
                 await warningAlert(
-                    context, 'Unexpected error has occurred: ${error}');
+                    context, 'Unexpected error has occurred: $error');
               }
             },
           ),

--- a/lib/src/screens/supa_reset_password.dart
+++ b/lib/src/screens/supa_reset_password.dart
@@ -71,7 +71,8 @@ class _SupaResetPasswordState extends State<SupaResetPassword> {
               } on GoTrueException catch (error) {
                 await warningAlert(context, error.message);
               } catch (error) {
-                await warningAlert(context, 'Unexpected error has occurred');
+                await warningAlert(
+                    context, 'Unexpected error has occurred: ${error}');
               }
             },
           ),

--- a/lib/src/screens/supa_reset_password.dart
+++ b/lib/src/screens/supa_reset_password.dart
@@ -6,10 +6,15 @@ import 'package:supabase_auth_ui/src/utils/constants.dart';
 class SupaResetPassword extends StatefulWidget {
   final String accessToken;
   final String? redirectUrl;
-  final void Function(GotrueUserResponse response)? callback;
+  final void Function(GotrueUserResponse response)? onSuccess;
+  final bool Function(GoTrueException error)? onError;
 
   const SupaResetPassword(
-      {Key? key, required this.accessToken, this.redirectUrl, this.callback})
+      {Key? key,
+      required this.accessToken,
+      this.redirectUrl,
+      this.onSuccess,
+      this.onError})
       : super(key: key);
 
   @override
@@ -62,14 +67,17 @@ class _SupaResetPasswordState extends State<SupaResetPassword> {
               try {
                 final result = await _supaAuth.updateUserPassword(
                     widget.accessToken, _password.text);
-                widget.callback?.call(result);
+                widget.onSuccess?.call(result);
                 if (!mounted) return;
                 await successAlert(context);
                 if (mounted) {
                   Navigator.popAndPushNamed(context, widget.redirectUrl ?? '/');
                 }
               } on GoTrueException catch (error) {
-                await warningAlert(context, error.message);
+                if (widget.onError == null ||
+                    widget.onError?.call(error) == false) {
+                  await warningAlert(context, error.message);
+                }
               } catch (error) {
                 await warningAlert(
                     context, 'Unexpected error has occurred: ${error}');

--- a/lib/src/screens/supa_reset_password.dart
+++ b/lib/src/screens/supa_reset_password.dart
@@ -5,16 +5,11 @@ import 'package:supabase_auth_ui/src/utils/constants.dart';
 
 class SupaResetPassword extends StatefulWidget {
   final String accessToken;
-  final String? redirectUrl;
   final void Function(GotrueUserResponse response)? onSuccess;
   final bool Function(GoTrueException error)? onError;
 
   const SupaResetPassword(
-      {Key? key,
-      required this.accessToken,
-      this.redirectUrl,
-      this.onSuccess,
-      this.onError})
+      {Key? key, required this.accessToken, this.onSuccess, this.onError})
       : super(key: key);
 
   @override
@@ -68,10 +63,8 @@ class _SupaResetPasswordState extends State<SupaResetPassword> {
                 final result = await _supaAuth.updateUserPassword(
                     widget.accessToken, _password.text);
                 widget.onSuccess?.call(result);
-                if (!mounted) return;
-                await successAlert(context);
-                if (mounted) {
-                  Navigator.popAndPushNamed(context, widget.redirectUrl ?? '/');
+                if (widget.onSuccess == null && mounted) {
+                  successAlert(context);
                 }
               } on GoTrueException catch (error) {
                 if (widget.onError == null ||

--- a/lib/src/screens/supa_send_email.dart
+++ b/lib/src/screens/supa_send_email.dart
@@ -70,12 +70,12 @@ class _SupaSendEmailState extends State<SupaSendEmail> {
                     style: TextStyle(fontWeight: FontWeight.bold),
                   ),
             onPressed: () async {
-              setState(() {
-                isLoading = true;
-              });
               if (!_formKey.currentState!.validate()) {
                 return;
               }
+              setState(() {
+                isLoading = true;
+              });
               try {
                 final result = await supaAuth.sendResetPasswordEmail(
                     _email.text, widget.redirectUrl);

--- a/lib/src/screens/supa_send_email.dart
+++ b/lib/src/screens/supa_send_email.dart
@@ -80,16 +80,16 @@ class _SupaSendEmailState extends State<SupaSendEmail> {
                 final result = await supaAuth.sendResetPasswordEmail(
                     _email.text, widget.redirectUrl);
                 widget.onSuccess?.call(result);
-                if (widget.onSuccess == null && mounted) {
-                  successAlert(context);
+                if (mounted) {
+                  successSnackBar(context, 'Email successfully sent !');
                 }
               } on GoTrueException catch (error) {
                 if (widget.onError == null ||
                     widget.onError?.call(error) == false) {
-                  await warningAlert(context, error.message);
+                  await warningSnackBar(context, error.message);
                 }
               } catch (error) {
-                await warningAlert(
+                await warningSnackBar(
                     context, 'Unexpected error has occurred: $error');
               }
               if (mounted) {

--- a/lib/src/screens/supa_send_email.dart
+++ b/lib/src/screens/supa_send_email.dart
@@ -87,7 +87,7 @@ class _SupaSendEmailState extends State<SupaSendEmail> {
                 }
               } catch (error) {
                 await warningAlert(
-                    context, 'Unexpected error has occurred: ${error}');
+                    context, 'Unexpected error has occurred: $error');
               }
               if (mounted) {
                 setState(() {

--- a/lib/src/screens/supa_send_email.dart
+++ b/lib/src/screens/supa_send_email.dart
@@ -81,7 +81,8 @@ class _SupaSendEmailState extends State<SupaSendEmail> {
               } on GoTrueException catch (error) {
                 await warningAlert(context, error.message);
               } catch (error) {
-                await warningAlert(context, 'Unexpected error has occurred');
+                await warningAlert(
+                    context, 'Unexpected error has occurred: ${error}');
               }
               if (mounted) {
                 setState(() {

--- a/lib/src/screens/supa_send_email.dart
+++ b/lib/src/screens/supa_send_email.dart
@@ -1,8 +1,8 @@
 import 'package:email_validator/email_validator.dart';
 import 'package:flutter/material.dart';
+import 'package:supabase_auth_ui/src/utils/constants.dart';
 import 'package:supabase_auth_ui/src/utils/supabase_auth_ui.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
-import 'package:supabase_auth_ui/src/utils/constants.dart';
 
 class SupaSendEmail extends StatefulWidget {
   final String? redirectUrl;
@@ -20,6 +20,8 @@ class _SupaSendEmailState extends State<SupaSendEmail> {
   final _email = TextEditingController();
 
   SupabaseAuthUi supaAuth = SupabaseAuthUi();
+
+  bool isLoading = false;
 
   @override
   void dispose() {
@@ -52,11 +54,23 @@ class _SupaSendEmailState extends State<SupaSendEmail> {
           ),
           spacer(16),
           ElevatedButton(
-            child: const Text(
-              'Send Reset Email',
-              style: TextStyle(fontWeight: FontWeight.bold),
-            ),
+            child: (isLoading)
+                ? const SizedBox(
+                    height: 16,
+                    width: 16,
+                    child: CircularProgressIndicator(
+                      color: Colors.white,
+                      strokeWidth: 1.5,
+                    ),
+                  )
+                : const Text(
+                    'Send Reset Email',
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                  ),
             onPressed: () async {
+              setState(() {
+                isLoading = true;
+              });
               if (!_formKey.currentState!.validate()) {
                 return;
               }
@@ -68,6 +82,11 @@ class _SupaSendEmailState extends State<SupaSendEmail> {
                 await warningAlert(context, error.message);
               } catch (error) {
                 await warningAlert(context, 'Unexpected error has occurred');
+              }
+              if (mounted) {
+                setState(() {
+                  isLoading = false;
+                });
               }
             },
           ),

--- a/lib/src/screens/supa_send_email.dart
+++ b/lib/src/screens/supa_send_email.dart
@@ -59,12 +59,13 @@ class _SupaSendEmailState extends State<SupaSendEmail> {
                 return;
               }
               try {
-                await supaAuth.sendResetPasswordEmail(_email.text);
                 if (!mounted) return;
                 await successAlert(context);
                 if (mounted) {
                   Navigator.popAndPushNamed(context, widget.redirectUrl ?? '/');
                 }
+                final result = await supaAuth.sendResetPasswordEmail(
+                    _email.text, widget.redirectUrl);
               } on GoTrueException catch (error) {
                 await warningAlert(context, error.message);
               } catch (error) {

--- a/lib/src/screens/supa_send_email.dart
+++ b/lib/src/screens/supa_send_email.dart
@@ -68,7 +68,7 @@ class _SupaSendEmailState extends State<SupaSendEmail> {
               } on GoTrueException catch (error) {
                 await warningAlert(context, error.message);
               } catch (error) {
-                await warningAlert(context, 'Unexpected error has occured');
+                await warningAlert(context, 'Unexpected error has occurred');
               }
               setState(() {
                 _email.text = '';

--- a/lib/src/screens/supa_send_email.dart
+++ b/lib/src/screens/supa_send_email.dart
@@ -80,6 +80,9 @@ class _SupaSendEmailState extends State<SupaSendEmail> {
                 final result = await supaAuth.sendResetPasswordEmail(
                     _email.text, widget.redirectUrl);
                 widget.onSuccess?.call(result);
+                if (widget.onSuccess == null && mounted) {
+                  successAlert(context);
+                }
               } on GoTrueException catch (error) {
                 if (widget.onError == null ||
                     widget.onError?.call(error) == false) {

--- a/lib/src/screens/supa_send_email.dart
+++ b/lib/src/screens/supa_send_email.dart
@@ -6,9 +6,11 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 class SupaSendEmail extends StatefulWidget {
   final String? redirectUrl;
-  final void Function(GotrueJsonResponse response)? callback;
+  final void Function(GotrueJsonResponse response)? onSuccess;
+  final bool Function(GoTrueException error)? onError;
 
-  const SupaSendEmail({Key? key, this.redirectUrl, this.callback})
+  const SupaSendEmail(
+      {Key? key, this.redirectUrl, this.onSuccess, this.onError})
       : super(key: key);
 
   @override
@@ -77,9 +79,12 @@ class _SupaSendEmailState extends State<SupaSendEmail> {
               try {
                 final result = await supaAuth.sendResetPasswordEmail(
                     _email.text, widget.redirectUrl);
-                widget.callback?.call(result);
+                widget.onSuccess?.call(result);
               } on GoTrueException catch (error) {
-                await warningAlert(context, error.message);
+                if (widget.onError == null ||
+                    widget.onError?.call(error) == false) {
+                  await warningAlert(context, error.message);
+                }
               } catch (error) {
                 await warningAlert(
                     context, 'Unexpected error has occurred: ${error}');

--- a/lib/src/screens/supa_send_email.dart
+++ b/lib/src/screens/supa_send_email.dart
@@ -6,8 +6,10 @@ import 'package:supabase_auth_ui/src/utils/constants.dart';
 
 class SupaSendEmail extends StatefulWidget {
   final String? redirectUrl;
+  final void Function(GotrueJsonResponse response)? callback;
 
-  const SupaSendEmail({Key? key, this.redirectUrl}) : super(key: key);
+  const SupaSendEmail({Key? key, this.redirectUrl, this.callback})
+      : super(key: key);
 
   @override
   State<SupaSendEmail> createState() => _SupaSendEmailState();
@@ -59,21 +61,14 @@ class _SupaSendEmailState extends State<SupaSendEmail> {
                 return;
               }
               try {
-                if (!mounted) return;
-                await successAlert(context);
-                if (mounted) {
-                  Navigator.popAndPushNamed(context, widget.redirectUrl ?? '/');
-                }
                 final result = await supaAuth.sendResetPasswordEmail(
                     _email.text, widget.redirectUrl);
+                widget.callback?.call(result);
               } on GoTrueException catch (error) {
                 await warningAlert(context, error.message);
               } catch (error) {
                 await warningAlert(context, 'Unexpected error has occurred');
               }
-              setState(() {
-                _email.text = '';
-              });
             },
           ),
           spacer(10),

--- a/lib/src/screens/supa_socials_auth.dart
+++ b/lib/src/screens/supa_socials_auth.dart
@@ -84,16 +84,16 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
                 await SupabaseAuthUi().socialSignIn(providers[index].name,
                     redirectUrl: widget.redirectUrl);
                 widget.onSuccess?.call();
-                if (widget.onSuccess == null && mounted) {
-                  successAlert(context);
+                if (mounted) {
+                  successSnackBar(context, 'Successfully signed in !');
                 }
               } on GoTrueException catch (error) {
                 if (widget.onError == null ||
                     widget.onError?.call(error) == false) {
-                  await warningAlert(context, error.message);
+                  await warningSnackBar(context, error.message);
                 }
               } catch (error) {
-                await warningAlert(
+                await warningSnackBar(
                     context, 'Unexpected error has occurred: $error');
               }
             },

--- a/lib/src/screens/supa_socials_auth.dart
+++ b/lib/src/screens/supa_socials_auth.dart
@@ -34,11 +34,14 @@ class SupaSocialsAuth extends StatefulWidget {
   final bool colored;
   final String? redirectUrl;
 
+  final void Function()? callback;
+
   const SupaSocialsAuth({
     Key? key,
     required this.socialProviders,
     required this.colored,
     this.redirectUrl,
+    this.callback,
   }) : super(key: key);
 
   @override
@@ -78,6 +81,7 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
               try {
                 await SupabaseAuthUi().socialSignIn(providers[index].name,
                     redirectUrl: widget.redirectUrl);
+                widget.callback?.call();
               } on GoTrueException catch (error) {
                 await warningAlert(context, error.message);
               } catch (error) {

--- a/lib/src/screens/supa_socials_auth.dart
+++ b/lib/src/screens/supa_socials_auth.dart
@@ -76,7 +76,8 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
             ),
             onPressed: () async {
               try {
-                await SupabaseAuthUi().socialSignIn(providers[index].name, widget.redirectUrl);
+                await SupabaseAuthUi().socialSignIn(providers[index].name,
+                    redirectUrl: widget.redirectUrl);
               } on GoTrueException catch (error) {
                 await warningAlert(context, error.message);
               } catch (error) {

--- a/lib/src/screens/supa_socials_auth.dart
+++ b/lib/src/screens/supa_socials_auth.dart
@@ -80,7 +80,7 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
               } on GoTrueException catch (error) {
                 await warningAlert(context, error.message);
               } catch (error) {
-                await warningAlert(context, 'Unexpected error has occured');
+                await warningAlert(context, 'Unexpected error has occurred');
               }
             },
             label: Text(

--- a/lib/src/screens/supa_socials_auth.dart
+++ b/lib/src/screens/supa_socials_auth.dart
@@ -85,7 +85,8 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
               } on GoTrueException catch (error) {
                 await warningAlert(context, error.message);
               } catch (error) {
-                await warningAlert(context, 'Unexpected error has occurred');
+                await warningAlert(
+                    context, 'Unexpected error has occurred: ${error}');
               }
             },
             label: Text(

--- a/lib/src/screens/supa_socials_auth.dart
+++ b/lib/src/screens/supa_socials_auth.dart
@@ -34,14 +34,16 @@ class SupaSocialsAuth extends StatefulWidget {
   final bool colored;
   final String? redirectUrl;
 
-  final void Function()? callback;
+  final void Function()? onSuccess;
+  final bool Function(GoTrueException error)? onError;
 
   const SupaSocialsAuth({
     Key? key,
     required this.socialProviders,
     required this.colored,
     this.redirectUrl,
-    this.callback,
+    this.onSuccess,
+    this.onError,
   }) : super(key: key);
 
   @override
@@ -81,9 +83,12 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
               try {
                 await SupabaseAuthUi().socialSignIn(providers[index].name,
                     redirectUrl: widget.redirectUrl);
-                widget.callback?.call();
+                widget.onSuccess?.call();
               } on GoTrueException catch (error) {
-                await warningAlert(context, error.message);
+                if (widget.onError == null ||
+                    widget.onError?.call(error) == false) {
+                  await warningAlert(context, error.message);
+                }
               } catch (error) {
                 await warningAlert(
                     context, 'Unexpected error has occurred: ${error}');

--- a/lib/src/screens/supa_socials_auth.dart
+++ b/lib/src/screens/supa_socials_auth.dart
@@ -84,6 +84,9 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
                 await SupabaseAuthUi().socialSignIn(providers[index].name,
                     redirectUrl: widget.redirectUrl);
                 widget.onSuccess?.call();
+                if (widget.onSuccess == null && mounted) {
+                  successAlert(context);
+                }
               } on GoTrueException catch (error) {
                 if (widget.onError == null ||
                     widget.onError?.call(error) == false) {

--- a/lib/src/screens/supa_socials_auth.dart
+++ b/lib/src/screens/supa_socials_auth.dart
@@ -84,7 +84,7 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
               }
             },
             label: Text(
-              'Sign in with ${providers[index].capitalizedName}',
+              'Continue with ${providers[index].capitalizedName}',
               style: TextStyle(
                 fontWeight: FontWeight.bold,
                 color: coloredBg ? Colors.white : Colors.black,

--- a/lib/src/screens/supa_socials_auth.dart
+++ b/lib/src/screens/supa_socials_auth.dart
@@ -91,7 +91,7 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
                 }
               } catch (error) {
                 await warningAlert(
-                    context, 'Unexpected error has occurred: ${error}');
+                    context, 'Unexpected error has occurred: $error');
               }
             },
             label: Text(

--- a/lib/src/screens/supa_verify_phone.dart
+++ b/lib/src/screens/supa_verify_phone.dart
@@ -66,14 +66,14 @@ class _SupaVerifyPhoneState extends State<SupaVerifyPhone> {
               try {
                 await supaAuth.verifyPhoneUser(data!["phone"], _code.text);
                 if (!mounted) return;
-                await successAlert(context);
+                await successSnackBar(context, 'Successfully verified !');
                 if (mounted) {
                   Navigator.popAndPushNamed(context, widget.redirectUrl ?? '/');
                 }
               } on GoTrueException catch (error) {
-                await warningAlert(context, error.message);
+                await warningSnackBar(context, error.message);
               } catch (error) {
-                await warningAlert(
+                await warningSnackBar(
                     context, 'Unexpected error has occurred: $error');
               }
               setState(() {

--- a/lib/src/screens/supa_verify_phone.dart
+++ b/lib/src/screens/supa_verify_phone.dart
@@ -73,7 +73,7 @@ class _SupaVerifyPhoneState extends State<SupaVerifyPhone> {
               } on GoTrueException catch (error) {
                 await warningAlert(context, error.message);
               } catch (error) {
-                await warningAlert(context, 'Unexpected error has occured');
+                await warningAlert(context, 'Unexpected error has occurred');
               }
               setState(() {
                 _code.text = '';

--- a/lib/src/screens/supa_verify_phone.dart
+++ b/lib/src/screens/supa_verify_phone.dart
@@ -74,7 +74,7 @@ class _SupaVerifyPhoneState extends State<SupaVerifyPhone> {
                 await warningAlert(context, error.message);
               } catch (error) {
                 await warningAlert(
-                    context, 'Unexpected error has occurred: ${error}');
+                    context, 'Unexpected error has occurred: $error');
               }
               setState(() {
                 _code.text = '';

--- a/lib/src/screens/supa_verify_phone.dart
+++ b/lib/src/screens/supa_verify_phone.dart
@@ -73,7 +73,8 @@ class _SupaVerifyPhoneState extends State<SupaVerifyPhone> {
               } on GoTrueException catch (error) {
                 await warningAlert(context, error.message);
               } catch (error) {
-                await warningAlert(context, 'Unexpected error has occurred');
+                await warningAlert(
+                    context, 'Unexpected error has occurred: ${error}');
               }
               setState(() {
                 _code.text = '';

--- a/lib/src/utils/constants.dart
+++ b/lib/src/utils/constants.dart
@@ -1,53 +1,25 @@
 import 'package:flutter/material.dart';
 
-Future<void> successAlert(BuildContext context) {
-  return showDialog(
-    context: context,
-    builder: (BuildContext context) {
-      return AlertDialog(
-        contentPadding: const EdgeInsets.all(16),
-        title: const Text(
-          'Success',
-          style: TextStyle(color: Colors.green),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text(
-              'OK',
-              style:
-                  TextStyle(fontWeight: FontWeight.bold, color: Colors.green),
-            ),
-          ),
-        ],
-      );
-    },
+Future<void> successSnackBar(BuildContext context, String succMsg) async {
+  final snackBar = SnackBar(
+    content: Text(style: const TextStyle(color: Colors.green), succMsg),
+    action: SnackBarAction(
+      label: 'Ok',
+      onPressed: () {},
+    ),
   );
+  ScaffoldMessenger.of(context).showSnackBar(snackBar);
 }
 
-Future<void> warningAlert(BuildContext context, String errMsg) {
-  return showDialog(
-    context: context,
-    builder: (BuildContext context) {
-      return AlertDialog(
-        contentPadding: const EdgeInsets.all(16),
-        title: Text(
-          errMsg,
-          style: const TextStyle(color: Colors.redAccent),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text(
-              'OK',
-              style: TextStyle(
-                  fontWeight: FontWeight.bold, color: Colors.redAccent),
-            ),
-          ),
-        ],
-      );
-    },
+Future<void> warningSnackBar(BuildContext context, String errMsg) async {
+  final snackBar = SnackBar(
+    content: Text(style: const TextStyle(color: Colors.redAccent), errMsg),
+    action: SnackBarAction(
+      label: 'Ok',
+      onPressed: () {},
+    ),
   );
+  ScaffoldMessenger.of(context).showSnackBar(snackBar);
 }
 
 SizedBox spacer(double height) {

--- a/lib/src/utils/supabase_auth_ui.dart
+++ b/lib/src/utils/supabase_auth_ui.dart
@@ -16,10 +16,13 @@ class SupabaseAuthUi {
     String password, {
     String? redirectUrl,
   }) {
-    return supaClient.auth.signUp(email, password,
-        options: AuthOptions(
-          redirectTo: redirectUrl,
-        ));
+    return supaClient.auth.signUp(
+      email,
+      password,
+      options: AuthOptions(
+        redirectTo: redirectUrl,
+      ),
+    );
   }
 
   /// Email-password sign in
@@ -50,7 +53,9 @@ class SupabaseAuthUi {
     return supaClient.auth.verifyOTP(
       phone,
       token,
-      options: AuthOptions(redirectTo: redirectUrl),
+      options: AuthOptions(
+        redirectTo: redirectUrl,
+      ),
     );
   }
 
@@ -68,10 +73,11 @@ class SupabaseAuthUi {
   Future<GotrueSessionResponse> createNewPasswordlessUser(String email,
       {String? redirectUrl}) {
     return supaClient.auth.signIn(
-        email: email,
-        options: AuthOptions(
-          redirectTo: redirectUrl,
-        ));
+      email: email,
+      options: AuthOptions(
+        redirectTo: redirectUrl,
+      ),
+    );
   }
 
   /// Social login with Google
@@ -80,8 +86,12 @@ class SupabaseAuthUi {
     String? redirectUrl,
   }) {
     final provider = Provider.values.byName(socialProvider);
-    return supaClient.auth.signInWithProvider(provider,
-        options: AuthOptions(redirectTo: redirectUrl));
+    return supaClient.auth.signInWithProvider(
+      provider,
+      options: AuthOptions(
+        redirectTo: redirectUrl,
+      ),
+    );
   }
 
   /// Sign out active user
@@ -109,7 +119,9 @@ class SupabaseAuthUi {
   ) {
     return supaClient.auth.api.updateUser(
       accessToken,
-      UserAttributes(password: password),
+      UserAttributes(
+        password: password,
+      ),
     );
   }
 

--- a/lib/src/utils/supabase_auth_ui.dart
+++ b/lib/src/utils/supabase_auth_ui.dart
@@ -13,9 +13,13 @@ class SupabaseAuthUi {
   /// Email-password sign up
   Future<GotrueSessionResponse> createNewEmailUser(
     String email,
-    String password,
-  ) {
-    return supaClient.auth.signUp(email, password);
+    String password, {
+    String? redirectUrl,
+  }) {
+    return supaClient.auth.signUp(email, password,
+        options: AuthOptions(
+          redirectTo: redirectUrl,
+        ));
   }
 
   /// Email-password sign in
@@ -61,17 +65,20 @@ class SupabaseAuthUi {
   }
 
   /// Email magic link sign in
-  Future<GotrueSessionResponse> createNewPasswordlessUser(String email) {
+  Future<GotrueSessionResponse> createNewPasswordlessUser(String email,
+      {String? redirectUrl}) {
     return supaClient.auth.signIn(
-      email: email,
-    );
+        email: email,
+        options: AuthOptions(
+          redirectTo: redirectUrl,
+        ));
   }
 
   /// Social login with Google
   Future<bool?> socialSignIn(
-    String socialProvider, [
+    String socialProvider, {
     String? redirectUrl,
-  ]) {
+  }) {
     final provider = Provider.values.byName(socialProvider);
     return supaClient.auth.signInWithProvider(provider,
         options: AuthOptions(redirectTo: redirectUrl));
@@ -90,7 +97,7 @@ class SupabaseAuthUi {
     return supaClient.auth.api.resetPasswordForEmail(
       email,
       options: AuthOptions(
-        redirectTo: redirectUrl ?? '',
+        redirectTo: redirectUrl,
       ),
     );
   }


### PR DESCRIPTION
- Users can decide how to react after the Supabase action finishes :
   - Add ```onSuccess``` callback instead of the success alert for most components. 
   - Add ```onError``` callback instead of the error alert for most components. 
   - For example callbacks are needed in order to display a page asking the user to verify their email when signing up or using a magic link.
- Fix some typos.
- Fix missing ```redirectUrl```.
- Add a ```CircularProgressIndicator```on some buttons.
- Reword some buttons to "Continue" when they both signin and signup. (Magic Link & Providers).
- Call signIn after signUp to handle cases where user already exists (or when email verification isn't set).