### PR TITLE
Polish the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ SupaEmailAuth(
     redirectUrl: kIsWeb
           ? null
           : 'io.supabase.flutter://reset-callback/'
-    onSuccess: (GotrueSessionResponse response) { 
+    onSuccess: (GotrueSessionResponse response) {
         // do something, for example: navigate('home');
     },
     onError: (error) {
@@ -47,7 +47,7 @@ SupaEmailAuth(
     redirectUrl: kIsWeb
           ? null
           : 'io.supabase.flutter://reset-callback/',
-    onSuccess: (GotrueSessionResponse response) { 
+    onSuccess: (GotrueSessionResponse response) {
         // do something, for example: navigate('home');
     },
     onError: (error) {
@@ -65,7 +65,7 @@ SupaMagicAuth(
     redirectUrl: kIsWeb
           ? null
           : 'io.supabase.flutter://reset-callback/',
-    onSuccess: (Session response) { 
+    onSuccess: (Session response) {
         // do something, for example: navigate('home');
     },
     onError: (error) {
@@ -80,11 +80,10 @@ Use `SupaResetPassword` to create a password reset form.
 
 ```dart
 SupaResetPassword(
-    accessToken: session.accessToken,
     redirectUrl: kIsWeb
           ? null
           : 'io.supabase.flutter://reset-callback/',
-    onSuccess: (GotrueUserResponse response) { 
+    onSuccess: (GotrueUserResponse response) {
         // do something, for example: navigate('home');
     },
     onError: (error) {
@@ -107,7 +106,7 @@ SupaSocialsAuth(
     redirectUrl: kIsWeb
           ? null
           : 'io.supabase.flutter://reset-callback/',
-    onSuccess: (Session response) { 
+    onSuccess: (Session response) {
         // do something, for example: navigate('home');
     },
     onError: (error) {

--- a/example/lib/forgot_password.dart
+++ b/example/lib/forgot_password.dart
@@ -16,7 +16,7 @@ class ForgotPassword extends StatelessWidget {
           children: [
             SupaSendEmail(
               onSuccess: (response) {
-                Navigator.of(context).pushReplacementNamed('/');
+                Navigator.of(context).pushReplacementNamed('/wait_for_email');
               },
             ),
             TextButton(

--- a/example/lib/forgot_password.dart
+++ b/example/lib/forgot_password.dart
@@ -21,20 +21,11 @@ class ForgotPassword extends StatelessWidget {
             ),
             TextButton(
               child: const Text(
-                'Forgot Password? Click here',
+                'Take me back to Sign In',
                 style: TextStyle(fontWeight: FontWeight.bold),
               ),
               onPressed: () {
-                Navigator.pushNamed(context, '/forgot_password');
-              },
-            ),
-            TextButton(
-              child: const Text(
-                'Take me back to Sign Up',
-                style: TextStyle(fontWeight: FontWeight.bold),
-              ),
-              onPressed: () {
-                Navigator.pushNamed(context, '/');
+                Navigator.pushNamed(context, '/sign_in');
               },
             ),
           ],

--- a/example/lib/forgot_password.dart
+++ b/example/lib/forgot_password.dart
@@ -16,7 +16,7 @@ class ForgotPassword extends StatelessWidget {
           children: [
             SupaSendEmail(
               onSuccess: (response) {
-                Navigator.of(context).pushReplacementNamed('/home');
+                Navigator.of(context).pushReplacementNamed('/');
               },
             ),
             TextButton(

--- a/example/lib/magic_link.dart
+++ b/example/lib/magic_link.dart
@@ -17,7 +17,7 @@ class MagicLink extends StatelessWidget {
           children: [
             SupaMagicAuth(
               onSuccess: (response) {
-                Navigator.of(context).pushReplacementNamed('/home');
+                Navigator.of(context).pushReplacementNamed('/wait_for_email');
               },
               redirectUrl: kIsWeb
                   ? null

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:example/phone_sign_up.dart';
+import 'package:example/wait_for_email.dart';
 import 'package:flutter/material.dart';
 import 'package:supabase_auth_ui/supabase_auth_ui.dart';
 
@@ -49,6 +50,7 @@ class MyApp extends StatelessWidget {
         '/phone_sign_in': (context) => const PhoneSignIn(),
         '/phone_sign_up': (context) => const PhoneSignUp(),
         '/verify_phone': (context) => const VerifyPhone(),
+        '/wait_for_email': (context) => const WaitForEmail(),
         '/home': (context) => const Home(),
       },
       onUnknownRoute: (RouteSettings settings) {

--- a/example/lib/sign_in.dart
+++ b/example/lib/sign_in.dart
@@ -14,11 +14,16 @@ class SignIn extends StatelessWidget {
         padding: const EdgeInsets.all(24.0),
         children: [
           SupaEmailAuth(
-            authAction: SupaAuthAction.signIn,
-            onSuccess: (response) {
-              Navigator.of(context).pushReplacementNamed('/home');
-            },
-          ),
+              authAction: SupaAuthAction.signIn,
+              onSuccess: (response) {
+                Navigator.of(context).pushReplacementNamed('/home');
+              },
+              onError: (error) {
+                if (error is GoTrueException &&
+                    error.message == "Email not confirmed") {
+                  Navigator.of(context).pushReplacementNamed("wait_for_email");
+                }
+              }),
           TextButton(
             child: const Text(
               'Forgot Password? Click here',

--- a/example/lib/update_password.dart
+++ b/example/lib/update_password.dart
@@ -15,8 +15,6 @@ class UpdatePassword extends StatelessWidget {
         child: Column(
           children: [
             SupaResetPassword(
-              accessToken:
-                  Supabase.instance.client.auth.currentSession!.accessToken,
               onSuccess: (response) {
                 Navigator.of(context).pushReplacementNamed('/home');
               },

--- a/example/lib/wait_for_email.dart
+++ b/example/lib/wait_for_email.dart
@@ -1,0 +1,22 @@
+import 'package:example/constants.dart';
+import 'package:flutter/material.dart';
+
+class WaitForEmail extends StatelessWidget {
+  const WaitForEmail({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: appBar,
+      body: const Padding(
+        padding: EdgeInsets.all(24.0),
+        child: Center(
+          child: Text(
+            'Please check your email.',
+            style: TextStyle(fontWeight: FontWeight.bold, color: Colors.blue),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/components/supa_email_auth.dart
+++ b/lib/src/components/supa_email_auth.dart
@@ -193,19 +193,8 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                   );
                 }
                 widget.onSuccess.call(response);
-              } on GoTrueException catch (error) {
-                if (widget.onError == null) {
-                  context.showErrorSnackBar(error.message);
-                } else {
-                  widget.onError?.call(error);
-                }
               } catch (error) {
-                if (widget.onError == null) {
-                  context.showErrorSnackBar(
-                      'Unexpected error has occurred: $error');
-                } else {
-                  widget.onError?.call(error);
-                }
+                handleError(context, error, widget.onError);
               }
               if (mounted) {
                 setState(() {

--- a/lib/src/components/supa_magic_auth.dart
+++ b/lib/src/components/supa_magic_auth.dart
@@ -97,7 +97,7 @@ class _SupaMagicAuthState extends State<SupaMagicAuth> {
                 _isLoading = true;
               });
               try {
-                await supaClient.auth.signIn(
+                final result = await supaClient.auth.signIn(
                   email: _email.text,
                   options: AuthOptions(
                     redirectTo: widget.redirectUrl,
@@ -106,19 +106,8 @@ class _SupaMagicAuthState extends State<SupaMagicAuth> {
                 if (mounted) {
                   context.showSnackBar('Check your email inbox!');
                 }
-              } on GoTrueException catch (error) {
-                if (widget.onError == null) {
-                  context.showErrorSnackBar(error.message);
-                } else {
-                  widget.onError?.call(error);
-                }
               } catch (error) {
-                if (widget.onError == null) {
-                  context.showErrorSnackBar(
-                      'Unexpected error has occurred: $error');
-                } else {
-                  widget.onError?.call(error);
-                }
+                handleError(context, error, widget.onError);
               }
               setState(() {
                 _isLoading = false;

--- a/lib/src/components/supa_phone_auth.dart
+++ b/lib/src/components/supa_phone_auth.dart
@@ -5,13 +5,13 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 /// UI component to create a phone + password signin/ signup form
 class SupaPhoneAuth extends StatefulWidget {
-  /// Whether the user is sining in or signin up
+  /// Whether the user is signing in or signing up
   final SupaAuthAction authAction;
 
   /// Method to be called when the auth action is success
   final void Function(GotrueSessionResponse response) onSuccess;
 
-  /// Method to be called when the auth action threw an excepction
+  /// Method to be called when the auth action threw an exception
   final void Function(Object error)? onError;
 
   const SupaPhoneAuth({
@@ -101,19 +101,8 @@ class _SupaPhoneAuthState extends State<SupaPhoneAuth> {
                   if (!mounted) return;
                   widget.onSuccess(response);
                 }
-              } on GoTrueException catch (error) {
-                if (widget.onError == null) {
-                  context.showErrorSnackBar(error.message);
-                } else {
-                  widget.onError?.call(error);
-                }
               } catch (error) {
-                if (widget.onError == null) {
-                  context.showErrorSnackBar(
-                      'Unexpected error has occurred: $error');
-                } else {
-                  widget.onError?.call(error);
-                }
+                handleError(context, error, widget.onError);
               }
               setState(() {
                 _phone.text = '';

--- a/lib/src/components/supa_reset_password.dart
+++ b/lib/src/components/supa_reset_password.dart
@@ -4,9 +4,6 @@ import 'package:supabase_auth_ui/src/utils/constants.dart';
 
 /// UI component to create password reset form
 class SupaResetPassword extends StatefulWidget {
-  /// accessToken of the user
-  final String? accessToken;
-
   /// Method to be called when the auth action is success
   final void Function(GotrueUserResponse response) onSuccess;
 
@@ -15,7 +12,6 @@ class SupaResetPassword extends StatefulWidget {
 
   const SupaResetPassword({
     Key? key,
-    this.accessToken,
     required this.onSuccess,
     this.onError,
   }) : super(key: key);
@@ -36,8 +32,7 @@ class _SupaResetPasswordState extends State<SupaResetPassword> {
 
   @override
   Widget build(BuildContext context) {
-    final accessToken =
-        widget.accessToken ?? supaClient.auth.currentSession!.accessToken;
+    final accessToken = supaClient.auth.currentSession!.accessToken;
     return Form(
       key: _formKey,
       child: Column(

--- a/lib/src/components/supa_reset_password.dart
+++ b/lib/src/components/supa_reset_password.dart
@@ -74,19 +74,8 @@ class _SupaResetPasswordState extends State<SupaResetPassword> {
                   ),
                 );
                 widget.onSuccess.call(response);
-              } on GoTrueException catch (error) {
-                if (widget.onError == null) {
-                  context.showErrorSnackBar(error.message);
-                } else {
-                  widget.onError?.call(error);
-                }
               } catch (error) {
-                if (widget.onError == null) {
-                  context.showErrorSnackBar(
-                      'Unexpected error has occurred: $error');
-                } else {
-                  widget.onError?.call(error);
-                }
+                handleError(context, error, widget.onError);
               }
             },
           ),

--- a/lib/src/components/supa_send_email.dart
+++ b/lib/src/components/supa_send_email.dart
@@ -91,7 +91,10 @@ class _SupaSendEmailState extends State<SupaSendEmail> {
                     redirectTo: widget.redirectUrl,
                   ),
                 );
-                widget.onSuccess.call(response);
+                if (mounted) {
+                  context.showSnackBar('Check your email inbox!');
+                  widget.onSuccess.call(response);
+                }
               } catch (error) {
                 handleError(context, error, widget.onError);
               }

--- a/lib/src/components/supa_send_email.dart
+++ b/lib/src/components/supa_send_email.dart
@@ -92,19 +92,8 @@ class _SupaSendEmailState extends State<SupaSendEmail> {
                   ),
                 );
                 widget.onSuccess.call(response);
-              } on GoTrueException catch (error) {
-                if (widget.onError == null) {
-                  context.showErrorSnackBar(error.message);
-                } else {
-                  widget.onError?.call(error);
-                }
               } catch (error) {
-                if (widget.onError == null) {
-                  context.showErrorSnackBar(
-                      'Unexpected error has occurred: $error');
-                } else {
-                  widget.onError?.call(error);
-                }
+                handleError(context, error, widget.onError);
               }
               if (mounted) {
                 setState(() {

--- a/lib/src/components/supa_socials_auth.dart
+++ b/lib/src/components/supa_socials_auth.dart
@@ -169,19 +169,8 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
                     redirectTo: widget.redirectUrl,
                   ),
                 );
-              } on GoTrueException catch (error) {
-                if (widget.onError == null) {
-                  context.showErrorSnackBar(error.message);
-                } else {
-                  widget.onError?.call(error);
-                }
               } catch (error) {
-                if (widget.onError == null) {
-                  context.showErrorSnackBar(
-                      'Unexpected error has occurred: $error');
-                } else {
-                  widget.onError?.call(error);
-                }
+                handleError(context, error, widget.onError);
               }
             },
             label: Text(

--- a/lib/src/components/supa_verify_phone.dart
+++ b/lib/src/components/supa_verify_phone.dart
@@ -74,19 +74,8 @@ class _SupaVerifyPhoneState extends State<SupaVerifyPhone> {
                   _code.text,
                 );
                 widget.onSuccess(response);
-              } on GoTrueException catch (error) {
-                if (widget.onError == null) {
-                  context.showErrorSnackBar(error.message);
-                } else {
-                  widget.onError?.call(error);
-                }
               } catch (error) {
-                if (widget.onError == null) {
-                  context.showErrorSnackBar(
-                      'Unexpected error has occurred: $error');
-                } else {
-                  widget.onError?.call(error);
-                }
+                handleError(context, error, widget.onError);
               }
               if (mounted) {
                 setState(() {

--- a/lib/src/utils/constants.dart
+++ b/lib/src/utils/constants.dart
@@ -39,3 +39,16 @@ extension ShowSnackBar on BuildContext {
     );
   }
 }
+
+void handleError(
+    BuildContext context, Object error, void Function(Object error)? onError) {
+  if (onError != null) {
+    onError.call(error);
+    return;
+  }
+  if (error is GoTrueException) {
+    context.showErrorSnackBar(error.message);
+  } else {
+    context.showErrorSnackBar('Unexpected error has occurred: $error');
+  }
+}


### PR DESCRIPTION
- refactor error handling into a single function

- example: remove unneeded accesstoken 
should we remove it from the readme?

- add a wait for email screen
ForgetPassword / MagicLink: onSuccess go to wait_for_email. (A snackbar is forcefully also emitted, seems a bit redundant)
What should we do? 
Also why does MagicLink have a special onSuccess handling?

SignIn: OnError('Email not confirmed') go to  wait_for_email. 
Note that we do not handle the other errors in that case. (the snackbar is not called any longer)
Should we have a special callback for email_not_confirmed?

SignUp: how do we redirect to wait_for_email? We were calling sign_in just after sign_up which had multiple benefits in my option: provide the same 'Email not confirmed' error, and signin user if there is no email confirmation or if their account already exists.
Happy to fix that also if you have a direction.