### PR TITLE
chore: publish v0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.1
+
+- BREAKING: update supabase_flutter to v1.0.0
+
 ## 0.0.1-dev.4
 
 - fix: image URL of Supabase logo in readme.md

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supabase_auth_ui
 description: UI library to implement auth forms using Supabase and Flutter
-version: 0.0.1-dev.4
+version: 0.0.1
 homepage: https://supabase.com
 repository: 'https://github.com/supabase-community/flutter-auth-ui'
 


### PR DESCRIPTION
I think now that supabase_flutter v1.0.0 is used, we can release v0.0.1 of this library. It is still in v0, so we can still introduce breaking changes if we need to. 