### PR TITLE
feat: Make SupaSocialsAuth success SnackBar optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1
+
+- feat: Make `SupaSocialsAuth` success SnackBar optional [#54](https://github.com/supabase-community/flutter-auth-ui/pull/54)
+
 ## 0.2.0
 
 - BREAKING: `SupaEmailAuth` now contains sign-up, sign-in, and forget email in a single instance [#46](https://github.com/supabase-community/flutter-auth-ui/pull/46)
@@ -44,25 +48,25 @@
 - feat: add phone auth support
 - fix: only validate forms upon submission
 - feat: `metadataFields` has been added to add additional fields to the signup form to pass data as metadata in Supabase
-    ```dart
-    SupaEmailAuth(
-        authAction: AuthAction.signUp,
-        metadataFields: [
-            MetaDataField(
-                prefixIcon: const Icon(Icons.person),
-                label: 'Username',
-                key: 'username',
-                validator: (val) {
-                    if (val == null || val.isEmpty) {
-                    return 'Please enter something';
-                    }
-                    return null;
-                },
-            ),
-        ],
-        onSuccess: _handleSignupSuccess,
-    )
-    ```
+  ```dart
+  SupaEmailAuth(
+      authAction: AuthAction.signUp,
+      metadataFields: [
+          MetaDataField(
+              prefixIcon: const Icon(Icons.person),
+              label: 'Username',
+              key: 'username',
+              validator: (val) {
+                  if (val == null || val.isEmpty) {
+                  return 'Please enter something';
+                  }
+                  return null;
+              },
+          ),
+      ],
+      onSuccess: _handleSignupSuccess,
+  )
+  ```
 
 ## 0.0.1-dev.2
 
@@ -75,4 +79,4 @@
 
 ## 0.0.1-dev.1
 
-- Initial developer preview release. 
+- Initial developer preview release.

--- a/lib/src/components/supa_socials_auth.dart
+++ b/lib/src/components/supa_socials_auth.dart
@@ -114,6 +114,9 @@ class SupaSocialsAuth extends StatefulWidget {
   /// Method to be called when the auth action threw an excepction
   final void Function(Object error)? onError;
 
+  /// Whether to show a SnackBar after a successful sign in
+  final bool showSuccessSnackBar;
+
   const SupaSocialsAuth({
     Key? key,
     required this.socialProviders,
@@ -122,6 +125,7 @@ class SupaSocialsAuth extends StatefulWidget {
     required this.onSuccess,
     this.onError,
     this.socialButtonVariant = SocialButtonVariant.iconAndText,
+    this.showSuccessSnackBar = true,
   }) : super(key: key);
 
   @override
@@ -139,7 +143,9 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
       final session = data.session;
       if (session != null && mounted) {
         widget.onSuccess.call(session);
-        context.showSnackBar('Successfully signed in !');
+        if (widget.showSuccessSnackBar) {
+          context.showSnackBar('Successfully signed in!');
+        }
       }
     });
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supabase_auth_ui
 description: UI library to implement auth forms using Supabase and Flutter
-version: 0.2.0
+version: 0.2.1
 homepage: https://supabase.com
 repository: 'https://github.com/supabase-community/flutter-auth-ui'
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

After using social auth the package shows a SnackBar with no option to not show it.

## What is the new behavior?

Added a bool to SupaSocialsAuth to give the developer the choice to have this SnackBar be shown. The bool is optional and the default value is true, causing no change from the current behavior without the developer setting it to false on their own.

Additionally removed an extra space between the word "in" in the SnackBar message and the ! at the end of the String.
