### PR TITLE
refactor: Changed OAuthProvider extension to unnamed only for private

### DIFF
--- a/lib/src/components/supa_socials_auth.dart
+++ b/lib/src/components/supa_socials_auth.dart
@@ -5,7 +5,7 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:supabase_auth_ui/src/utils/constants.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
-extension SocialProvidersa on OAuthProvider {
+extension on OAuthProvider {
   IconData get _iconData => switch (this) {
         OAuthProvider.apple => FontAwesomeIcons.apple,
         OAuthProvider.azure => FontAwesomeIcons.microsoft,

--- a/lib/src/components/supa_socials_auth.dart
+++ b/lib/src/components/supa_socials_auth.dart
@@ -6,7 +6,7 @@ import 'package:supabase_auth_ui/src/utils/constants.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 extension on OAuthProvider {
-  IconData get _iconData => switch (this) {
+  IconData get iconData => switch (this) {
         OAuthProvider.apple => FontAwesomeIcons.apple,
         OAuthProvider.azure => FontAwesomeIcons.microsoft,
         OAuthProvider.bitbucket => FontAwesomeIcons.bitbucket,
@@ -24,7 +24,7 @@ extension on OAuthProvider {
         _ => Icons.close,
       };
 
-  Color get _btnBgColor => switch (this) {
+  Color get btnBgColor => switch (this) {
         OAuthProvider.apple => Colors.black,
         OAuthProvider.azure => Colors.blueAccent,
         OAuthProvider.bitbucket => Colors.blue,
@@ -139,7 +139,7 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
         final socialProvider = providers[index];
 
         Color? foregroundColor = coloredBg ? Colors.white : null;
-        Color? backgroundColor = coloredBg ? socialProvider._btnBgColor : null;
+        Color? backgroundColor = coloredBg ? socialProvider.btnBgColor : null;
         Color? overlayColor = coloredBg ? Colors.white10 : null;
 
         Color? iconColor = coloredBg ? Colors.white : null;
@@ -148,7 +148,7 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
           height: 48,
           width: 48,
           child: Icon(
-            socialProvider._iconData,
+            socialProvider.iconData,
             color: iconColor,
           ),
         );


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Use [unnamed extension](https://dart.dev/language/extension-methods#unnamed-extensions) only for private.
- Remove unnecessary prefix underscore(`_`) because unnamed extension’s methods and static menbers are only visible within the declaration.

In previous code, the extension getters allows you to access from outside, even though they have an underscore (_) prefix.

```dart
import 'src/components/supa_socials_auth.dart';

OAuthProvider.apple._iconData;
```
