### PR TITLE
Headless signup user metadata option

### DIFF
--- a/lib/src/components/supa_email_auth.dart
+++ b/lib/src/components/supa_email_auth.dart
@@ -67,13 +67,16 @@ class SupaEmailAuth extends StatefulWidget {
   /// Callback for sending the password reset email
   final void Function()? onPasswordResetEmailSent;
 
-  /// Callback for when the auth action threw an excepction
+  /// Callback for when the auth action threw an exception
   ///
   /// If set to `null`, a snack bar with error color will show up.
   final void Function(Object error)? onError;
 
+  /// Set of additional fields to the signup form that will become
+  /// part of the user_metadata
   final List<MetaDataField>? metadataFields;
 
+  /// Additional properties for user_metadata on signup
   final Map<String, dynamic>? extraMetadata;
 
   /// {@macro supa_email_auth}
@@ -295,12 +298,17 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
     );
   }
 
+  /// Resolve the user_metadata that we will send during sign-up
+  ///
+  /// In case both MetadataFields and extraMetadata have the same
+  /// key in their map, the MetadataFields (form fields) win
   Map<String, dynamic> _resolveData() {
     var extra = widget.extraMetadata ?? <String, dynamic>{};
     extra.addAll(_resolveMetadataFieldsData());
     return extra;
   }
 
+  /// Resolve the user_metadata coming from the metadataFields
   Map<String, dynamic> _resolveMetadataFieldsData() {
     return widget.metadataFields != null
       ? _metadataControllers.map<String, dynamic>(

--- a/lib/src/components/supa_email_auth.dart
+++ b/lib/src/components/supa_email_auth.dart
@@ -74,6 +74,8 @@ class SupaEmailAuth extends StatefulWidget {
 
   final List<MetaDataField>? metadataFields;
 
+  final Map<String, dynamic>? extraMetadata;
+
   /// {@macro supa_email_auth}
   const SupaEmailAuth({
     Key? key,
@@ -83,6 +85,7 @@ class SupaEmailAuth extends StatefulWidget {
     this.onPasswordResetEmailSent,
     this.onError,
     this.metadataFields,
+    this.extraMetadata
   }) : super(key: key);
 
   @override
@@ -204,11 +207,7 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                       email: _emailController.text.trim(),
                       password: _passwordController.text.trim(),
                       emailRedirectTo: widget.redirectTo,
-                      data: widget.metadataFields == null
-                          ? null
-                          : _metadataControllers.map<String, dynamic>(
-                              (metaDataField, controller) =>
-                                  MapEntry(metaDataField.key, controller.text)),
+                      data: _resolveData(),
                     );
                     widget.onSignUpComplete.call(response);
                   }
@@ -294,5 +293,19 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
         ],
       ),
     );
+  }
+
+  Map<String, dynamic> _resolveData() {
+    var extra = widget.extraMetadata ?? <String, dynamic>{};
+    extra.addAll(_resolveMetadataFieldsData());
+    return extra;
+  }
+
+  Map<String, dynamic> _resolveMetadataFieldsData() {
+    return widget.metadataFields != null
+      ? _metadataControllers.map<String, dynamic>(
+          (metaDataField, controller) =>
+          MapEntry(metaDataField.key, controller.text))
+      : <String, dynamic>{};
   }
 }

--- a/lib/src/components/supa_email_auth.dart
+++ b/lib/src/components/supa_email_auth.dart
@@ -88,7 +88,7 @@ class SupaEmailAuth extends StatefulWidget {
     this.onPasswordResetEmailSent,
     this.onError,
     this.metadataFields,
-    this.extraMetadata
+    this.extraMetadata,
   }) : super(key: key);
 
   @override
@@ -311,9 +311,9 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
   /// Resolve the user_metadata coming from the metadataFields
   Map<String, dynamic> _resolveMetadataFieldsData() {
     return widget.metadataFields != null
-      ? _metadataControllers.map<String, dynamic>(
-          (metaDataField, controller) =>
-          MapEntry(metaDataField.key, controller.text))
-      : <String, dynamic>{};
+        ? _metadataControllers.map<String, dynamic>(
+            (metaDataField, controller) =>
+                MapEntry(metaDataField.key, controller.text))
+        : <String, dynamic>{};
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature: possibility to add "headless" metadata in email signup

## What is the current behavior?

The only user metadata that can be added today is through extra text fields
But you can add data using the plain `supabase.auth.signUp(data: ...)` call

## What is the new behavior?

One can add extra user metadata information that don't need to be exposed or chosen by the user.

## Additional context

Example: a User type. If I show the signup form is in a "Player" screen, i want to pass `type: "player"` as metadata behind the scenes.
