### PR TITLE
Update SupaSocialsAuth to pass scopes and query params to signInWithOAuth

### DIFF
--- a/lib/src/components/supa_socials_auth.dart
+++ b/lib/src/components/supa_socials_auth.dart
@@ -85,6 +85,12 @@ class SupaSocialsAuth extends StatefulWidget {
   /// Whether to show a SnackBar after a successful sign in
   final bool showSuccessSnackBar;
 
+  /// OpenID scope(s) for provider authorization request (ex. '.default')
+  final String? scopes;
+
+  /// Parameters to include in provider authorization request (ex. {'prompt': 'consent'})
+  final Map<String, String>? queryParams;
+
   const SupaSocialsAuth({
     Key? key,
     required this.socialProviders,
@@ -94,6 +100,8 @@ class SupaSocialsAuth extends StatefulWidget {
     this.onError,
     this.socialButtonVariant = SocialButtonVariant.iconAndText,
     this.showSuccessSnackBar = true,
+    this.scopes,
+    this.queryParams,
   }) : super(key: key);
 
   @override
@@ -209,6 +217,8 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
             await supabase.auth.signInWithOAuth(
               socialProvider,
               redirectTo: widget.redirectUrl,
+              scopes: widget.scopes,
+              queryParams: widget.queryParams,
             );
           } on AuthException catch (error) {
             if (widget.onError == null && context.mounted) {

--- a/lib/src/components/supa_socials_auth.dart
+++ b/lib/src/components/supa_socials_auth.dart
@@ -86,10 +86,10 @@ class SupaSocialsAuth extends StatefulWidget {
   final bool showSuccessSnackBar;
 
   /// OpenID scope(s) for provider authorization request (ex. '.default')
-  final String? scopes;
+  final Map<OAuthProvider, String>? scopes;
 
   /// Parameters to include in provider authorization request (ex. {'prompt': 'consent'})
-  final Map<String, String>? queryParams;
+  final Map<OAuthProvider, Map<String, String>>? queryParams;
 
   const SupaSocialsAuth({
     Key? key,
@@ -217,8 +217,8 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
             await supabase.auth.signInWithOAuth(
               socialProvider,
               redirectTo: widget.redirectUrl,
-              scopes: widget.scopes,
-              queryParams: widget.queryParams,
+              scopes: widget.scopes?[socialProvider],
+              queryParams: widget.queryParams?[socialProvider],
             );
           } on AuthException catch (error) {
             if (widget.onError == null && context.mounted) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix/Enhancement to SupaSocialsAuth.

## What is the current behavior?

Without the `scopes` and ability to include `prompt=consent` in the provider OpenID `/authorize` request, users are never given the opportunity to grant permissions to an app beyond just the ability to sign in.

## What is the new behavior?

It is now possible to add scopes and query parameters to `SocialsAuth`.
```
SocialsAuth(
  socialProviders: [
    SocialProviders.azure,
  ],
  colored: true,
  redirectUrl: authService.redirectUrl,
  onSuccess: (Session response) {},
  onError: (error) {},
  scopes: '.default',
  queryParams: (promptConsent) ? {'prompt': 'consent'} : {},
)
```
This example triggers a consent prompt for all permissions the Azure app registration has requested. 
https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#the-default-scope

## Additional context

This is a requirement for apps using Azure Active Directory and the Microsoft Graph API unless we want to make an Azure AD admin manually grant permissions through the Azure console any time they change.