### PR TITLE
Add autofill hints

### DIFF
--- a/lib/src/components/supa_email_auth.dart
+++ b/lib/src/components/supa_email_auth.dart
@@ -152,7 +152,9 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
           if (!_forgotPassword) ...[
             spacer(16),
             TextFormField(
-              autofillHints: _isSigningIn ? [AutofillHints.password] : [AutofillHints.newPassword],
+              autofillHints: _isSigningIn
+                  ? [AutofillHints.password]
+                  : [AutofillHints.newPassword],
               validator: (value) {
                 if (value == null || value.isEmpty || value.length < 6) {
                   return 'Please enter a password that is at least 6 characters long';

--- a/lib/src/components/supa_email_auth.dart
+++ b/lib/src/components/supa_email_auth.dart
@@ -152,6 +152,7 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
           if (!_forgotPassword) ...[
             spacer(16),
             TextFormField(
+              autofillHints: const [AutofillHints.password],
               validator: (value) {
                 if (value == null || value.isEmpty || value.length < 6) {
                   return 'Please enter a password that is at least 6 characters long';

--- a/lib/src/components/supa_email_auth.dart
+++ b/lib/src/components/supa_email_auth.dart
@@ -152,7 +152,7 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
           if (!_forgotPassword) ...[
             spacer(16),
             TextFormField(
-              autofillHints: const [AutofillHints.password],
+              autofillHints: _isSigningIn ? [AutofillHints.password] : [AutofillHints.newPassword],
               validator: (value) {
                 if (value == null || value.isEmpty || value.length < 6) {
                   return 'Please enter a password that is at least 6 characters long';

--- a/lib/src/components/supa_phone_auth.dart
+++ b/lib/src/components/supa_phone_auth.dart
@@ -65,7 +65,9 @@ class _SupaPhoneAuthState extends State<SupaPhoneAuth> {
           ),
           spacer(16),
           TextFormField(
-            autofillHints: isSigningIn ? [AutofillHints.password] : [AutofillHints.newPassword],
+            autofillHints: isSigningIn
+                ? [AutofillHints.password]
+                : [AutofillHints.newPassword],
             validator: (value) {
               if (value == null || value.isEmpty || value.length < 6) {
                 return 'Please enter a password that is at least 6 characters long';

--- a/lib/src/components/supa_phone_auth.dart
+++ b/lib/src/components/supa_phone_auth.dart
@@ -50,6 +50,7 @@ class _SupaPhoneAuthState extends State<SupaPhoneAuth> {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           TextFormField(
+            autofillHints: const [AutofillHints.telephoneNumber],
             validator: (value) {
               if (value == null || value.isEmpty) {
                 return 'Please enter a valid phone number';
@@ -64,6 +65,7 @@ class _SupaPhoneAuthState extends State<SupaPhoneAuth> {
           ),
           spacer(16),
           TextFormField(
+            autofillHints: isSigningIn ? [AutofillHints.password] : [AutofillHints.newPassword],
             validator: (value) {
               if (value == null || value.isEmpty || value.length < 6) {
                 return 'Please enter a password that is at least 6 characters long';

--- a/lib/src/components/supa_reset_password.dart
+++ b/lib/src/components/supa_reset_password.dart
@@ -42,6 +42,7 @@ class _SupaResetPasswordState extends State<SupaResetPassword> {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           TextFormField(
+            autofillHints: const [AutofillHints.newPassword],
             validator: (value) {
               if (value == null || value.isEmpty || value.length < 6) {
                 return 'Please enter a password that is at least 6 characters long';


### PR DESCRIPTION
## What kind of change does this PR introduce?

Make flutter-auth-ui work well with password managers.

## What is the current behavior?

Password managers are unable to pick up the password field.

## What is the new behavior?

Password managers can pick up the password field.
