### PR TITLE
Add TextInputAction to phone and email sign in

### DIFF
--- a/lib/src/components/supa_email_auth.dart
+++ b/lib/src/components/supa_email_auth.dart
@@ -141,6 +141,8 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
           TextFormField(
             keyboardType: TextInputType.emailAddress,
             autofillHints: const [AutofillHints.email],
+            textInputAction:
+                _forgotPassword ? TextInputAction.done : TextInputAction.next,
             validator: (value) {
               if (value == null ||
                   value.isEmpty ||
@@ -161,6 +163,9 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
               autofillHints: _isSigningIn
                   ? [AutofillHints.password]
                   : [AutofillHints.newPassword],
+              textInputAction: widget.metadataFields != null && !_isSigningIn
+                  ? TextInputAction.next
+                  : TextInputAction.done,
               validator: (value) {
                 if (value == null || value.isEmpty || value.length < 6) {
                   return localization.passwordLengthError;
@@ -180,6 +185,10 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                   .map((metadataField) => [
                         TextFormField(
                           controller: _metadataControllers[metadataField],
+                          textInputAction:
+                              widget.metadataFields!.last == metadataField
+                                  ? TextInputAction.done
+                                  : TextInputAction.next,
                           decoration: InputDecoration(
                             label: Text(metadataField.label),
                             prefixIcon: metadataField.prefixIcon,

--- a/lib/src/components/supa_phone_auth.dart
+++ b/lib/src/components/supa_phone_auth.dart
@@ -56,6 +56,7 @@ class _SupaPhoneAuthState extends State<SupaPhoneAuth> {
         children: [
           TextFormField(
             autofillHints: const [AutofillHints.telephoneNumber],
+            textInputAction: TextInputAction.next,
             validator: (value) {
               if (value == null || value.isEmpty) {
                 return localization.validPhoneNumberError;
@@ -73,6 +74,7 @@ class _SupaPhoneAuthState extends State<SupaPhoneAuth> {
             autofillHints: isSigningIn
                 ? [AutofillHints.password]
                 : [AutofillHints.newPassword],
+            textInputAction: TextInputAction.done,
             validator: (value) {
               if (value == null || value.isEmpty || value.length < 6) {
                 return localization.passwordLengthError;


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR introduces [TextInputActions](https://api.flutter.dev/flutter/services/TextInputAction.html) to the email and phone sign-up/-in forms.

## What is the current behavior?

#81

## What is the new behavior?

A small QoL change in the way that phone keyboards are configured for traversing the forms. The change is the "next" right arrows button in the bottom right of the keyboard.

[with actions.webm](https://github.com/supabase-community/flutter-auth-ui/assets/24683548/af53401f-be44-4ebd-bd48-38e4e57e59a1)


## Additional context

Add any other context or screenshots.
