### PR TITLE
Add redirectTo for email password reset

### DIFF
--- a/lib/src/components/supa_email_auth.dart
+++ b/lib/src/components/supa_email_auth.dart
@@ -284,7 +284,7 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                     });
 
                     final email = _emailController.text.trim();
-                    await supabase.auth.resetPasswordForEmail(email);
+                    await supabase.auth.resetPasswordForEmail(email, redirectTo: widget.redirectTo);
                     widget.onPasswordResetEmailSent?.call();
                   } on AuthException catch (error) {
                     widget.onError?.call(error);

--- a/lib/src/components/supa_email_auth.dart
+++ b/lib/src/components/supa_email_auth.dart
@@ -284,7 +284,10 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                     });
 
                     final email = _emailController.text.trim();
-                    await supabase.auth.resetPasswordForEmail(email, redirectTo: widget.redirectTo);
+                    await supabase.auth.resetPasswordForEmail(
+                      email,
+                      redirectTo: widget.redirectTo,
+                    );
                     widget.onPasswordResetEmailSent?.call();
                   } on AuthException catch (error) {
                     widget.onError?.call(error);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The E-Mail will use the URL from the configuration inside the Supabase dashboard. However, when using e.g. a sub package which is different from the configured URL, the E-Mail will provide the wrong link and the user can't reset his password.

## What is the new behavior?

It will use the redirectTo field as expected.
