### PR TITLE
add a dedicated redirect url parameter for a password reset flow

### DIFF
--- a/lib/src/components/supa_email_auth.dart
+++ b/lib/src/components/supa_email_auth.dart
@@ -57,6 +57,10 @@ class SupaEmailAuth extends StatefulWidget {
   /// confirmation link after signing up.
   final String? redirectTo;
 
+  /// The URL to redirect the user to when clicking on the link on the
+  /// confirmation link from a reset password confirm email.
+  final String? redirectToResetPwd;
+
   /// Callback for the user to complete a sign in.
   final void Function(AuthResponse response) onSignInComplete;
 
@@ -87,6 +91,7 @@ class SupaEmailAuth extends StatefulWidget {
   const SupaEmailAuth({
     Key? key,
     this.redirectTo,
+    this.redirectToResetPwd,
     required this.onSignInComplete,
     required this.onSignUpComplete,
     this.onPasswordResetEmailSent,
@@ -295,7 +300,7 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                     final email = _emailController.text.trim();
                     await supabase.auth.resetPasswordForEmail(
                       email,
-                      redirectTo: widget.redirectTo,
+                      redirectTo: widget.redirectToResetPwd,
                     );
                     widget.onPasswordResetEmailSent?.call();
                     // FIX use_build_context_synchronously


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR addresses an issue where the redirectTo in SupaEmailAuth, intended for confirming a signup email, was also used for the password reset confirmation flow. This overlap makes it difficult to implement a follow-up UX flow, such as transitioning to the password reset screen after verifying the redirect URL for a password reset.

## What is the current behavior?

Currently, after clicking on the confirmation URL in a password reset confirmation email, the application receives the same redirect URL set for the signup confirmation flow.

## What is the new behavior?

With this change, the application will receive a dedicated redirect URL for password reset, distinct from the signup confirmation URL.

## Additional context

While the app can subscribe to the AuthChangeEvent.passwordRecovery event to handle the password reset flow, redirecting with the exact deep link URL provides a more straightforward approach.