### PR TITLE
feat: Allow password recovery email to be redirected to other URL

### DIFF
--- a/lib/src/components/supa_email_auth.dart
+++ b/lib/src/components/supa_email_auth.dart
@@ -57,6 +57,12 @@ class SupaEmailAuth extends StatefulWidget {
   /// confirmation link after signing up.
   final String? redirectTo;
 
+  /// The URL to redirect the user to when clicking on the link on the
+  /// password recovery link.
+  ///
+  /// If unspecified, the [redirectTo] value will be used.
+  final String? resetPasswordRedirectTo;
+
   /// Callback for the user to complete a sign in.
   final void Function(AuthResponse response) onSignInComplete;
 
@@ -87,6 +93,7 @@ class SupaEmailAuth extends StatefulWidget {
   const SupaEmailAuth({
     super.key,
     this.redirectTo,
+    this.resetPasswordRedirectTo,
     required this.onSignInComplete,
     required this.onSignUpComplete,
     this.onPasswordResetEmailSent,
@@ -295,7 +302,8 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                     final email = _emailController.text.trim();
                     await supabase.auth.resetPasswordForEmail(
                       email,
-                      redirectTo: widget.redirectTo,
+                      redirectTo:
+                          widget.resetPasswordRedirectTo ?? widget.redirectTo,
                     );
                     widget.onPasswordResetEmailSent?.call();
                     // FIX use_build_context_synchronously


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds a new `resetPasswordRedirectTo` so that users can be redirected to a different URL for password recovery flow.
