### PR TITLE
feat!: Allow the OAuth provider labels to be overridden on `SupaSocialsAuth`

### DIFF
--- a/lib/src/components/supa_socials_auth.dart
+++ b/lib/src/components/supa_socials_auth.dart
@@ -54,7 +54,8 @@ extension on OAuthProvider {
         _ => Colors.black,
       };
 
-  String get capitalizedName => name[0].toUpperCase() + name.substring(1);
+  String get labelText =>
+      'Continue with ${name[0].toUpperCase()}${name.substring(1)}';
 }
 
 enum SocialButtonVariant {
@@ -383,8 +384,8 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
                   icon: iconWidget,
                   style: authButtonStyle,
                   onPressed: onAuthButtonPressed,
-                  label: Text(
-                      '${localization.continueWith} ${socialProvider.capitalizedName}'),
+                  label: Text(localization.oAuthButtonLabels[socialProvider] ??
+                      '${localization.continueWith} ${socialProvider.labelText}'),
                 ),
         );
       },

--- a/lib/src/components/supa_socials_auth.dart
+++ b/lib/src/components/supa_socials_auth.dart
@@ -54,7 +54,8 @@ extension on OAuthProvider {
         _ => Colors.black,
       };
 
-  String get labelText => '${name[0].toUpperCase()}${name.substring(1)}';
+  String get labelText =>
+      'Continue with ${name[0].toUpperCase()}${name.substring(1)}';
 }
 
 enum SocialButtonVariant {
@@ -383,8 +384,10 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
                   icon: iconWidget,
                   style: authButtonStyle,
                   onPressed: onAuthButtonPressed,
-                  label: Text(localization.oAuthButtonLabels[socialProvider] ??
-                      '${localization.continueWith} ${socialProvider.labelText}'),
+                  label: Text(
+                    localization.oAuthButtonLabels[socialProvider] ??
+                        socialProvider.labelText,
+                  ),
                 ),
         );
       },

--- a/lib/src/components/supa_socials_auth.dart
+++ b/lib/src/components/supa_socials_auth.dart
@@ -54,8 +54,7 @@ extension on OAuthProvider {
         _ => Colors.black,
       };
 
-  String get labelText =>
-      'Continue with ${name[0].toUpperCase()}${name.substring(1)}';
+  String get labelText => '${name[0].toUpperCase()}${name.substring(1)}';
 }
 
 enum SocialButtonVariant {

--- a/lib/src/localizations/supa_socials_auth_localization.dart
+++ b/lib/src/localizations/supa_socials_auth_localization.dart
@@ -4,15 +4,16 @@ class SupaSocialsAuthLocalization {
   final String updatePassword;
   final String successSignInMessage;
   final String unexpectedError;
-  final String continueWith;
 
   /// Overrides the name of the OAuth provider shown on the sign-in button.
+  ///
+  /// Defaults to the provider's name.
   ///
   /// ```dart
   /// SupaSocialsAuth(
   ///   socialProviders: const [OAuthProvider.azure],
   ///   localization: const SupaSocialsAuthLocalization(
-  ///     oAuthProviderLabelOverrides: {
+  ///     oAuthButtonLabels: {
   ///       OAuthProvider.azure: 'Microsoft (Azure)'
   ///     },
   ///   ),
@@ -21,13 +22,12 @@ class SupaSocialsAuthLocalization {
   ///   },
   /// ),
   /// ```
-  final Map<OAuthProvider, String> oAuthProviderLabelOverrides;
+  final Map<OAuthProvider, String> oAuthButtonLabels;
 
   const SupaSocialsAuthLocalization({
     this.updatePassword = 'Update Password',
     this.successSignInMessage = 'Successfully signed in!',
     this.unexpectedError = 'An unexpected error occurred',
-    this.continueWith = 'Continue with',
-    this.oAuthProviderLabelOverrides = const {},
+    this.oAuthButtonLabels = const {},
   });
 }

--- a/lib/src/localizations/supa_socials_auth_localization.dart
+++ b/lib/src/localizations/supa_socials_auth_localization.dart
@@ -2,7 +2,6 @@ import 'package:supabase_auth_ui/supabase_auth_ui.dart';
 
 class SupaSocialsAuthLocalization {
   final String continueWith;
-  final String updatePassword;
   final String successSignInMessage;
   final String unexpectedError;
 
@@ -27,7 +26,6 @@ class SupaSocialsAuthLocalization {
 
   const SupaSocialsAuthLocalization({
     this.continueWith = 'Continue with',
-    this.updatePassword = 'Update Password',
     this.successSignInMessage = 'Successfully signed in!',
     this.unexpectedError = 'An unexpected error occurred',
     this.oAuthButtonLabels = const {},

--- a/lib/src/localizations/supa_socials_auth_localization.dart
+++ b/lib/src/localizations/supa_socials_auth_localization.dart
@@ -1,13 +1,33 @@
+import 'package:supabase_auth_ui/supabase_auth_ui.dart';
+
 class SupaSocialsAuthLocalization {
   final String updatePassword;
   final String successSignInMessage;
   final String unexpectedError;
   final String continueWith;
 
+  /// Overrides the name of the OAuth provider shown on the sign-in button.
+  ///
+  /// ```dart
+  /// SupaSocialsAuth(
+  ///   socialProviders: const [OAuthProvider.azure],
+  ///   localization: const SupaSocialsAuthLocalization(
+  ///     oAuthProviderLabelOverrides: {
+  ///       OAuthProvider.azure: 'Microsoft (Azure)'
+  ///     },
+  ///   ),
+  ///   onSuccess: (session) {
+  ///     // sHandle success
+  ///   },
+  /// ),
+  /// ```
+  final Map<OAuthProvider, String> oAuthProviderLabelOverrides;
+
   const SupaSocialsAuthLocalization({
     this.updatePassword = 'Update Password',
     this.successSignInMessage = 'Successfully signed in!',
     this.unexpectedError = 'An unexpected error occurred',
     this.continueWith = 'Continue with',
+    this.oAuthProviderLabelOverrides = const {},
   });
 }

--- a/lib/src/localizations/supa_socials_auth_localization.dart
+++ b/lib/src/localizations/supa_socials_auth_localization.dart
@@ -1,6 +1,7 @@
 import 'package:supabase_auth_ui/supabase_auth_ui.dart';
 
 class SupaSocialsAuthLocalization {
+  final String continueWith;
   final String updatePassword;
   final String successSignInMessage;
   final String unexpectedError;
@@ -25,6 +26,7 @@ class SupaSocialsAuthLocalization {
   final Map<OAuthProvider, String> oAuthButtonLabels;
 
   const SupaSocialsAuthLocalization({
+    this.continueWith = 'Continue with',
     this.updatePassword = 'Update Password',
     this.successSignInMessage = 'Successfully signed in!',
     this.unexpectedError = 'An unexpected error occurred',

--- a/lib/src/localizations/supa_socials_auth_localization.dart
+++ b/lib/src/localizations/supa_socials_auth_localization.dart
@@ -7,7 +7,7 @@ class SupaSocialsAuthLocalization {
 
   /// Overrides the name of the OAuth provider shown on the sign-in button.
   ///
-  /// Defaults to the provider's name.
+  /// Defaults to `Continue with [ProviderName]`
   ///
   /// ```dart
   /// SupaSocialsAuth(

--- a/lib/src/localizations/supa_socials_auth_localization.dart
+++ b/lib/src/localizations/supa_socials_auth_localization.dart
@@ -1,7 +1,6 @@
 import 'package:supabase_auth_ui/supabase_auth_ui.dart';
 
 class SupaSocialsAuthLocalization {
-  final String continueWith;
   final String successSignInMessage;
   final String unexpectedError;
 
@@ -25,7 +24,6 @@ class SupaSocialsAuthLocalization {
   final Map<OAuthProvider, String> oAuthButtonLabels;
 
   const SupaSocialsAuthLocalization({
-    this.continueWith = 'Continue with',
     this.successSignInMessage = 'Successfully signed in!',
     this.unexpectedError = 'An unexpected error occurred',
     this.oAuthButtonLabels = const {},


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds a localization feature to override the OAuth provider name

```dart
SupaSocialsAuth(
  socialProviders: const [OAuthProvider.azure],
  localization: const SupaSocialsAuthLocalization(
    oAuthButtonLabels: {
      OAuthProvider.azure: 'Continue with Microsoft (Azure)'
    },
  ),
  onSuccess: (session) {
    // sHandle success
  },
),
```
Closes https://github.com/supabase-community/flutter-auth-ui/issues/87