### PR TITLE
Fix MetadataFields text field values being lost in SupaEmailAuth widget (Fixes #113)

### DIFF
--- a/lib/src/components/supa_email_auth.dart
+++ b/lib/src/components/supa_email_auth.dart
@@ -36,6 +36,16 @@ class MetaDataField {
     this.validator,
     this.prefixIcon,
   });
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MetaDataField &&
+          runtimeType == other.runtimeType &&
+          key == other.key;
+
+  @override
+  int get hashCode => key.hashCode;
 }
 
 /// {@template supa_email_auth}
@@ -125,7 +135,7 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
   final _formKey = GlobalKey<FormState>();
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
-  late final Map<MetaDataField, TextEditingController> _metadataControllers;
+  late final Map<String, TextEditingController> _metadataControllers;
 
   bool _isLoading = false;
 
@@ -142,7 +152,8 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
   void initState() {
     super.initState();
     _metadataControllers = Map.fromEntries((widget.metadataFields ?? []).map(
-        (metadataField) => MapEntry(metadataField, TextEditingController())));
+        (metadataField) =>
+            MapEntry(metadataField.key, TextEditingController())));
   }
 
   @override
@@ -225,7 +236,7 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                 ...widget.metadataFields!
                     .map((metadataField) => [
                           TextFormField(
-                            controller: _metadataControllers[metadataField],
+                            controller: _metadataControllers[metadataField.key],
                             textInputAction:
                                 widget.metadataFields!.last == metadataField
                                     ? TextInputAction.done
@@ -423,8 +434,7 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
   Map<String, dynamic> _resolveMetadataFieldsData() {
     return widget.metadataFields != null
         ? _metadataControllers.map<String, dynamic>(
-            (metaDataField, controller) =>
-                MapEntry(metaDataField.key, controller.text))
+            (key, controller) => MapEntry(key, controller.text))
         : <String, dynamic>{};
   }
 }

--- a/lib/src/components/supa_email_auth.dart
+++ b/lib/src/components/supa_email_auth.dart
@@ -36,16 +36,6 @@ class MetaDataField {
     this.validator,
     this.prefixIcon,
   });
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is MetaDataField &&
-          runtimeType == other.runtimeType &&
-          key == other.key;
-
-  @override
-  int get hashCode => key.hashCode;
 }
 
 /// {@template supa_email_auth}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes #113, where the values of text fields for MetadataFields on the SupaEmailAuth widget were getting lost, causing them to submit empty strings.

## What is the current behavior?

The cause of the issue was how the SupaEmailAuth widget was storing TextEditingControllers for the MetadataFields in the map `_metadataControllers`, with an instance of the MetadataField being used as the key, with a TextEditingController as the value.

Later, in the `build()` method, the list of MetaDataFields were iterated upon, with each accessing its corresponding controller in the map. Unfortunately, at this point the MetadataField would be a separate instance with different hashkeys, so the original TextEditingController stored in the map would not be retrieved.

Flutter handles this failure silently; if a null value is passed to `TextFormField.controller`, then the text field just creates a new controller. However, on form submission, the `_resolveMetadataFieldsData()` method looks to the controllers stored in `_metadataControllers`, which would still contain empty strings.

## What is the new behavior?

Update _SupaEmailAuthState to use MetadataField.key as map key instead of the MetadataField instance itself, and update related methods to work with new map structure.

## Additional Notes

An earlier version of this change also added an equality operator override and a hashcode getter to the MetadataField class. Claude had insisted that both this change and the change to the map of controllers was necessary, however since we're no longer using MetadataField instances as keys, it's no longer necessary to compare them.