### PR TITLE
Feature: Add BooleanMetaDataField to support checkbox inputs on sign-up form

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ SupaEmailAuth(
     // do something, for example: navigate("wait_for_email");
   },
   metadataFields: [
+    // Creates an additional TextField for string metadata, for example:
+    // {'username': 'exampleUsername'}
     MetaDataField(
       prefixIcon: const Icon(Icons.person),
       label: 'Username',
@@ -38,8 +40,38 @@ SupaEmailAuth(
         return null;
       },
     ),
-  ],
-),
+
+    // Creates a CheckboxListTile for boolean metadata, for example:
+    // {'marketing_consent': true}
+    BooleanMetaDataField(
+      label: 'I wish to receive marketing emails',
+      key: 'marketing_consent',
+      checkboxPosition: ListTileControlAffinity.leading,
+    ),
+    // Supports interactive text. Fields can be marked as required, blocking form
+    // submission unless the checkbox is checked.
+    BooleanMetaDataField(
+      key: 'terms_agreement',
+      isRequired: true,
+      checkboxPosition: ListTileControlAffinity.leading,
+      richLabelSpans: [
+        const TextSpan(
+            text: 'I have read and agree to the '),
+        TextSpan(
+          text: 'Terms and Conditions',
+          style: const TextStyle(
+            color: Colors.blue,
+          ),
+          recognizer: TapGestureRecognizer()
+            ..onTap = () {
+              // do something, for example: navigate("terms_and_conditions");
+            },
+        ),
+        // Or use some other custom widget.
+        WidgetSpan()
+      ],
+    ),
+  ]),
 ```
 
 ## Magic Link Auth

--- a/example/lib/sign_in.dart
+++ b/example/lib/sign_in.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:supabase_auth_ui/supabase_auth_ui.dart';
 
@@ -26,12 +27,16 @@ class SignUp extends StatelessWidget {
           borderRadius: BorderRadius.circular(8),
           borderSide: BorderSide.none,
         ),
-        labelStyle: const TextStyle(color: Color.fromARGB(179, 255, 255, 255)), // text labeling text entry
+        labelStyle: const TextStyle(
+            color:
+                Color.fromARGB(179, 255, 255, 255)), // text labeling text entry
       ),
       elevatedButtonTheme: ElevatedButtonThemeData(
         style: ElevatedButton.styleFrom(
-          backgroundColor: const Color.fromARGB(255, 22, 135, 188), // main button
-          foregroundColor: const Color.fromARGB(255, 255, 255, 255), // main button text
+          backgroundColor:
+              const Color.fromARGB(255, 22, 135, 188), // main button
+          foregroundColor:
+              const Color.fromARGB(255, 255, 255, 255), // main button text
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(8),
           ),
@@ -60,6 +65,32 @@ class SignUp extends StatelessWidget {
                   return null;
                 },
               ),
+              // Checkbox on the right
+              BooleanMetaDataField(
+                label: 'I agree to a checkbox on the right',
+                key: 'right_checkbox',
+              ),
+
+              // Checkbox on the left
+              BooleanMetaDataField(
+                key: 'terms_agreement',
+                required: true,
+                checkboxPosition: ListTileControlAffinity.leading,
+                richLabelSpans: [
+                  const TextSpan(text: 'I have read and agree to the '),
+                  TextSpan(
+                    text: 'Terms and Conditions',
+                    style: const TextStyle(
+                      color: Colors.blue,
+                    ),
+                    recognizer: TapGestureRecognizer()
+                      ..onTap = () {
+                        //ignore: avoid_print
+                        print('Terms and Conditions');
+                      },
+                  ),
+                ],
+              ),
             ],
           ),
 
@@ -76,17 +107,54 @@ class SignUp extends StatelessWidget {
                 child: Theme(
                   data: darkModeThemeData,
                   child: SupaEmailAuth(
-                    redirectTo: kIsWeb ? null : 'io.supabase.flutter://',
-                    onSignInComplete: navigateHome,
-                    onSignUpComplete: navigateHome,
-                    prefixIconEmail: null,
-                    prefixIconPassword: null,
-                    localization: const SupaEmailAuthLocalization(
-                        enterEmail: "email",
-                        enterPassword: "password",
-                        dontHaveAccount: "sign up",
-                        forgotPassword: "forgot password"),
-                  ),
+                      redirectTo: kIsWeb ? null : 'io.supabase.flutter://',
+                      onSignInComplete: navigateHome,
+                      onSignUpComplete: navigateHome,
+                      prefixIconEmail: null,
+                      prefixIconPassword: null,
+                      localization: const SupaEmailAuthLocalization(
+                          enterEmail: "email",
+                          enterPassword: "password",
+                          dontHaveAccount: "sign up",
+                          forgotPassword: "forgot password"),
+                      metadataFields: [
+                        MetaDataField(
+                          prefixIcon: const Icon(Icons.person),
+                          label: 'Username',
+                          key: 'username',
+                          validator: (val) {
+                            if (val == null || val.isEmpty) {
+                              return 'Please enter something';
+                            }
+                            return null;
+                          },
+                        ),
+                        BooleanMetaDataField(
+                          label: 'I wish to receive marketing emails',
+                          key: 'marketing_consent',
+                          checkboxPosition: ListTileControlAffinity.leading,
+                        ),
+                        BooleanMetaDataField(
+                          key: 'terms_agreement',
+                          required: true,
+                          checkboxPosition: ListTileControlAffinity.leading,
+                          richLabelSpans: [
+                            const TextSpan(
+                                text: 'I have read and agree to the '),
+                            TextSpan(
+                              text: 'Terms and Conditions',
+                              style: const TextStyle(
+                                color: Colors.blue,
+                              ),
+                              recognizer: TapGestureRecognizer()
+                                ..onTap = () {
+                                  //ignore: avoid_print
+                                  print('Terms and Conditions');
+                                },
+                            ),
+                          ],
+                        ),
+                      ]),
                 ),
               )),
 

--- a/example/lib/sign_in.dart
+++ b/example/lib/sign_in.dart
@@ -65,16 +65,14 @@ class SignUp extends StatelessWidget {
                   return null;
                 },
               ),
-              // Checkbox on the right
               BooleanMetaDataField(
-                label: 'I agree to a checkbox on the right',
-                key: 'right_checkbox',
+                label: 'Keep me up to date with the latest news and updates.',
+                key: 'marketing_consent',
+                checkboxPosition: ListTileControlAffinity.leading,
               ),
-
-              // Checkbox on the left
               BooleanMetaDataField(
                 key: 'terms_agreement',
-                required: true,
+                isRequired: true,
                 checkboxPosition: ListTileControlAffinity.leading,
                 richLabelSpans: [
                   const TextSpan(text: 'I have read and agree to the '),
@@ -85,8 +83,7 @@ class SignUp extends StatelessWidget {
                     ),
                     recognizer: TapGestureRecognizer()
                       ..onTap = () {
-                        //ignore: avoid_print
-                        print('Terms and Conditions');
+                        // Handle tap on Terms and Conditions
                       },
                   ),
                 ],
@@ -130,19 +127,20 @@ class SignUp extends StatelessWidget {
                           },
                         ),
                         BooleanMetaDataField(
-                          label: 'I wish to receive marketing emails',
+                          label:
+                              'Keep me up to date with the latest news and updates.',
                           key: 'marketing_consent',
                           checkboxPosition: ListTileControlAffinity.leading,
                         ),
                         BooleanMetaDataField(
                           key: 'terms_agreement',
-                          required: true,
+                          isRequired: true,
                           checkboxPosition: ListTileControlAffinity.leading,
                           richLabelSpans: [
                             const TextSpan(
                                 text: 'I have read and agree to the '),
                             TextSpan(
-                              text: 'Terms and Conditions',
+                              text: 'Terms and Conditions.',
                               style: const TextStyle(
                                 color: Colors.blue,
                               ),

--- a/lib/src/components/supa_email_auth.dart
+++ b/lib/src/components/supa_email_auth.dart
@@ -102,7 +102,7 @@ class BooleanMetaDataField extends MetaDataField {
   /// Whether the field is required.
   ///
   /// If true, the user must check the checkbox in order for the form to submit.
-  final bool required;
+  final bool isRequired;
 
   /// Semantic label for the checkbox.
   final String? checkboxSemanticLabel;
@@ -112,7 +112,7 @@ class BooleanMetaDataField extends MetaDataField {
     String? label,
     this.richLabelSpans,
     this.checkboxSemanticLabel,
-    this.required = false,
+    this.isRequired = false,
     this.checkboxPosition = ListTileControlAffinity.platform,
     required super.key,
   })  : assert(label != null || richLabelSpans != null,
@@ -120,9 +120,9 @@ class BooleanMetaDataField extends MetaDataField {
         super(label: label ?? '');
 
   Widget getLabelWidget(BuildContext context) {
-    // It's important that this matches the default style of [TextField], which
-    // is used for the other fields in the form. TextField's default style
-    // uses bodyLarge for Material 3, or otherwise titleMedium.
+    // This matches the default style of [TextField], to match the other fields
+    // in the form. TextField's default style uses `bodyLarge` for Material 3,
+    // or otherwise `titleMedium`.
     final defaultStyle = Theme.of(context).useMaterial3
         ? Theme.of(context).textTheme.bodyLarge
         : Theme.of(context).textTheme.titleMedium;
@@ -333,10 +333,11 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                 ...widget.metadataFields!
                     .map((metadataField) => [
                           // Render a Checkbox that displays an error message
-                          // beneath it if the field is required and the user hasn't checked it when submitting.
+                          // beneath it if the field is required and the user
+                          // hasn't checked it when submitting the form.
                           if (metadataField is BooleanMetaDataField)
                             FormField<bool>(
-                              validator: metadataField.required
+                              validator: metadataField.isRequired
                                   ? (bool? value) {
                                       if (value != true) {
                                         return localization.requiredFieldError;
@@ -368,6 +369,9 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                                           metadataField.checkboxSemanticLabel,
                                       controlAffinity:
                                           metadataField.checkboxPosition,
+                                      contentPadding:
+                                          const EdgeInsets.symmetric(
+                                              horizontal: 4.0),
                                       activeColor: theme.colorScheme.primary,
                                       checkColor: theme.colorScheme.onPrimary,
                                       tileColor: isDark

--- a/lib/src/localizations/supa_email_auth_localization.dart
+++ b/lib/src/localizations/supa_email_auth_localization.dart
@@ -12,6 +12,7 @@ class SupaEmailAuthLocalization {
   final String passwordResetSent;
   final String backToSignIn;
   final String unexpectedError;
+  final String requiredFieldError;
 
   const SupaEmailAuthLocalization({
     this.enterEmail = 'Enter your email',
@@ -28,5 +29,6 @@ class SupaEmailAuthLocalization {
     this.passwordResetSent = 'Password reset email has been sent',
     this.backToSignIn = 'Back to sign in',
     this.unexpectedError = 'An unexpected error occurred',
+    this.requiredFieldError = 'This field is required',
   });
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This commit adds a new `BooleanMetaDataField` class to support checkbox inputs
in the `SupaEmailAuth` component for boolean metadata. This enhancement allows for more versatile form
creation, particularly useful for consent checkboxes or boolean preferences.

Resolves #96 

Key changes:

1. New `BooleanMetaDataField` class:
   - Extends `MetaDataField` to maintain compatibility
   - Supports both simple text labels and rich text labels with interactive elements
   - Supports semantic labeling for accessibility
   - Allows customization of checkbox position (leading or trailing)
   - Includes a 'required' option for mandatory fields

2. Updates to `SupaEmailAuth`:
   - Modified to handle both `MetaDataField` and `BooleanMetaDataField`
   - Implemented rendering logic for checkbox fields
   - Added support for rich text labels in checkboxes
   - Implemented validation for required checkbox fields

3. Styling:
   - Ensured checkbox styling matches other form elements in both light and dark mode
   - Implemented error message display for invalid checkbox fields
   - Error message added to localization class

4. Documentation:
   - Added comprehensive documentation for `BooleanMetaDataField`
   - Updated existing documentation to reflect new capabilities

5. Example updates:
   - Modified example code to demonstrate usage of `BooleanMetaDataField`
   - Included examples of both simple and rich text labels

6. Backward compatibility:
   - Maintained support for existing `MetaDataField` usage
   - No breaking changes to public API

This enhancement provides developers with more flexibility in creating
sign-up forms, particularly for scenarios requiring user consent or
boolean preferences, while maintaining the existing functionality
of the `SupaEmailAuth` component.

## Additional context

There's quite a lot here, so while I've supplied screenshots, I recommend viewing the change in the example app to get a sense of its behavior. Don't hesitate to push back or question any decisions I made.

There are two specific issues that I would like feedback on before this PR gets approved, since any future changes to `BooleanMetaDataField` could be breaking:

1. I'm a bit ambivalent on how interactive text is passed in. At first I had a `richLabel` property that took a single `RichText` widget, but that won't match the styling of the other components on the form unless users of this library match it themselves. It felt too customizable, when all that the class really needs is a list of text widgets so it can arrange them like:
<Checkbox>"<some text><some linkable text><maybe some more text>".

So I modified it to instead take a `List<InlineSpan>`, and keep the `RichText` widget internal and give it a default style that matches the other fields in the form. If needed, the style can be overridden in the widgets that are passed in (for example, making a link blue).

2. Accessibility support: I wanted this to work out of the box with screen readers, which it _mostly_ does. I built the example app in Windows and used the Windows screen reader tool. The `BooleanMetaDataField` will focus like any other field in the form, and when selected, the `label` or `semanticsLabel` will be read aloud appropriately.

The only issue I had was getting the screen reader to select and read aloud any links or interactive text within the `richLabelSpan`. The ideal (and expected) behavior would be:

1. [Focus on "I agree to the terms and conditions" and read semantic label]
2. Press tab to focus on next focusNode 
3. [Focus on "terms and conditions" and read semantic label, like "Link to terms and conditions"]
4. Press tab to activate link

I wanted this to work out of the box, but it was a bit more difficult than I anticipated. Only step one works. Pressing tab again will focus on the next form component or the submit button.

I eventually got the subtext focusable, but I was never able to get the screen reader to read it aloud. The further I got into making that work, the more complex this change got, and after a certain point it just seemed out of scope. I have a lengthy change stashed on my fork that _almost_ works, but for now I think users of this library will have to handle accessibility themselves for whatever widgets are passed in to `richLabelSpan`. If I figure out a clean and easily-maintainable way to handle it, I'll submit another PR.

## Screenshots
Desktop:
![Screenshot 2024-10-03 143305](https://github.com/user-attachments/assets/9d704432-4a14-4f2a-8408-e7bc6f36d60a)
![Screenshot 2024-10-03 143313](https://github.com/user-attachments/assets/a8c66b7f-1ce3-48b4-85d0-5a3a6cbe6cf7)
![Screenshot 2024-10-03 143326](https://github.com/user-attachments/assets/42729dfc-d141-4bc6-b6d3-8a10d4ebcdf2)
![Screenshot 2024-10-03 143336](https://github.com/user-attachments/assets/b072271a-3e13-47fc-b3df-7b757e148c2c)

Mobile:
![Screenshot_1727990090](https://github.com/user-attachments/assets/7282270e-17f7-4c96-a28d-b6d4031bac7d)
![Screenshot_1727990121](https://github.com/user-attachments/assets/1d1ef425-b442-43df-9a64-99968c0907d4)
![Screenshot_1727990129](https://github.com/user-attachments/assets/f145001f-ffa6-4c93-a12a-680f6ef66b7a)

