### PR TITLE
Add autovalidation and remove hardcoded styling from checkboxes

### DIFF
--- a/lib/src/components/supa_email_auth.dart
+++ b/lib/src/components/supa_email_auth.dart
@@ -364,8 +364,6 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                                   : null,
                               builder: (FormFieldState<bool> field) {
                                 final theme = Theme.of(context);
-                                final isDark =
-                                    theme.brightness == Brightness.dark;
 
                                 return Column(
                                   crossAxisAlignment: CrossAxisAlignment.start,
@@ -389,24 +387,6 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                                       contentPadding:
                                           const EdgeInsets.symmetric(
                                               horizontal: 4.0),
-                                      activeColor: theme.colorScheme.primary,
-                                      checkColor: theme.colorScheme.onPrimary,
-                                      tileColor: isDark
-                                          ? theme.inputDecorationTheme.fillColor
-                                          : null,
-                                      shape: RoundedRectangleBorder(
-                                        borderRadius: BorderRadius.circular(4),
-                                        side: BorderSide(
-                                          color: field.hasError
-                                              ? theme.colorScheme.error
-                                              : theme
-                                                      .inputDecorationTheme
-                                                      .border
-                                                      ?.borderSide
-                                                      .color ??
-                                                  theme.dividerColor,
-                                        ),
-                                      ),
                                     ),
                                     if (field.hasError)
                                       Padding(
@@ -440,6 +420,8 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                                 prefixIcon: metadataField.prefixIcon,
                               ),
                               validator: metadataField.validator,
+                              autovalidateMode:
+                                  AutovalidateMode.onUserInteraction,
                               onFieldSubmitted: (_) {
                                 if (metadataField !=
                                     widget.metadataFields!.last) {


### PR DESCRIPTION
- Add autoFormValidation to MetaDataField (fixes #123)

  Fixes issue where form could submit with MetaDataField in an invalid state. New behavior matches that of password and email fields.

- Remove hardcoded styling for BooleanMetaDataField to prevent it from overriding an app's ThemeData (fixes #124)

  Fixes issue where border outlines would always appear. New behavior leaves styling up to ThemeData. If users of this library request it, we could potentially add these back as parameters for BooleanMetaDataField to pass down to its child CheckboxListTile, but that doesn't seem necessary for now.
  

