### PR TITLE
Add Confirm Password Field to SupaEmailAuth Component for Sign-Up Process

### DIFF
--- a/lib/src/components/supa_email_auth.dart
+++ b/lib/src/components/supa_email_auth.dart
@@ -214,6 +214,9 @@ class SupaEmailAuth extends StatefulWidget {
   final Widget? prefixIconEmail;
   final Widget? prefixIconPassword;
 
+  /// Whether the confirm password field should be displayed
+  final bool showConfirmPasswordField;
+
   /// {@macro supa_email_auth}
   const SupaEmailAuth({
     super.key,
@@ -232,6 +235,7 @@ class SupaEmailAuth extends StatefulWidget {
     this.isInitiallySigningIn = true,
     this.prefixIconEmail = const Icon(Icons.email),
     this.prefixIconPassword = const Icon(Icons.lock),
+    this.showConfirmPasswordField = false,
   });
 
   @override
@@ -242,6 +246,7 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
   final _formKey = GlobalKey<FormState>();
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
+  final _confirmPasswordController = TextEditingController();
   late bool _isSigningIn;
   late final Map<String, MetadataController> _metadataControllers;
 
@@ -271,6 +276,7 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
   void dispose() {
     _emailController.dispose();
     _passwordController.dispose();
+    _confirmPasswordController.dispose();
     for (final controller in _metadataControllers.values) {
       if (controller is TextEditingController) {
         controller.dispose();
@@ -345,6 +351,23 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                   }
                 },
               ),
+              if (widget.showConfirmPasswordField && !_isSigningIn) ...[
+                spacer(16),
+                TextFormField(
+                  controller: _confirmPasswordController,
+                  decoration: InputDecoration(
+                    prefixIcon: widget.prefixIconPassword,
+                    label: Text(localization.confirmPassword),
+                  ),
+                  obscureText: true,
+                  validator: (value) {
+                    if (value != _passwordController.text) {
+                      return localization.confirmPasswordError;
+                    }
+                    return null;
+                  },
+                ),
+              ],
               spacer(16),
               if (widget.metadataFields != null && !_isSigningIn)
                 ...widget.metadataFields!

--- a/lib/src/localizations/supa_email_auth_localization.dart
+++ b/lib/src/localizations/supa_email_auth_localization.dart
@@ -13,6 +13,8 @@ class SupaEmailAuthLocalization {
   final String backToSignIn;
   final String unexpectedError;
   final String requiredFieldError;
+  final String confirmPasswordError;
+  final String confirmPassword;
 
   const SupaEmailAuthLocalization({
     this.enterEmail = 'Enter your email',
@@ -30,5 +32,7 @@ class SupaEmailAuthLocalization {
     this.backToSignIn = 'Back to sign in',
     this.unexpectedError = 'An unexpected error occurred',
     this.requiredFieldError = 'This field is required',
+    this.confirmPasswordError = 'Passwords do not match',
+    this.confirmPassword = 'Confirm Password',
   });
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Currently, the SupaEmailAuth component does not include a field for confirming the password during the sign-up process. This can lead to user errors if they mistype their password without realizing it.

## What is the new behavior?

This PR introduces a new feature that adds a "Confirm Password" field to the SupaEmailAuth component, which is only displayed during the sign-up process. This field ensures that users enter their password correctly by requiring them to type it twice. The localization for the "Confirm Password" label and error message has also been added to support multiple languages.

## Additional context

![image](https://github.com/user-attachments/assets/e4109ae1-538e-463d-a9e5-15291e5a4b85)
