### PR TITLE
feat: add password recovery with OTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - BREAKING: `onPasswordResetEmailSent` now passes the email the reset was requested for, changing its signature from `void Function()?` to `void Function(String email)?` [#146](https://github.com/supabase-community/flutter-auth-ui/pull/146)
 - feat: Add a show/hide visibility toggle to password fields [#149](https://github.com/supabase-community/flutter-auth-ui/pull/149)
 - feat: Add showSnackBars option to make snack bars optional across all auth components [#150](https://github.com/supabase-community/flutter-auth-ui/pull/150)
+- feat: Add password recovery with OTP to SupaEmailAuth [#130](https://github.com/supabase-community/flutter-auth-ui/pull/130)
 
 ## 0.5.5
 

--- a/lib/src/components/supa_email_auth.dart
+++ b/lib/src/components/supa_email_auth.dart
@@ -543,6 +543,12 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                     prefixIcon: widget.prefixIconOtp,
                   ),
                   keyboardType: TextInputType.number,
+                  validator: (value) {
+                    if (value == null || value.trim().isEmpty) {
+                      return localization.requiredFieldError;
+                    }
+                    return null;
+                  },
                 ),
                 spacer(16),
                 TextFormField(
@@ -588,6 +594,7 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                 onPressed: () {
                   setState(() {
                     _isRecoveringPassword = false;
+                    _isEnteringOtp = false;
                   });
                 },
                 child: Text(localization.backToSignIn),
@@ -674,28 +681,22 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
 
       final email = _emailController.text.trim();
 
-      if (widget.useOtpForPasswordRecovery) {
-        await supabase.auth.resetPasswordForEmail(
-          email,
-          redirectTo: widget.resetPasswordRedirectTo ?? widget.redirectTo,
-        );
-        if (!mounted) return;
+      await supabase.auth.resetPasswordForEmail(
+        email,
+        redirectTo: widget.resetPasswordRedirectTo ?? widget.redirectTo,
+      );
+      widget.onPasswordResetEmailSent?.call(email);
+      if (!mounted) return;
+      if (widget.showSnackBars) {
         context.showSnackBar(widget.localization.passwordResetSent);
-        setState(() {
-          _isEnteringOtp = true;
-        });
-      } else {
-        await supabase.auth.resetPasswordForEmail(
-          email,
-          redirectTo: widget.resetPasswordRedirectTo ?? widget.redirectTo,
-        );
-        widget.onPasswordResetEmailSent?.call(email);
-        if (!mounted) return;
-        context.showSnackBar(widget.localization.passwordResetSent);
-        setState(() {
-          _isRecoveringPassword = false;
-        });
       }
+      setState(() {
+        if (widget.useOtpForPasswordRecovery) {
+          _isEnteringOtp = true;
+        } else {
+          _isRecoveringPassword = false;
+        }
+      });
     } on AuthException catch (error) {
       widget.onError?.call(error);
     } catch (error) {

--- a/lib/src/components/supa_email_auth.dart
+++ b/lib/src/components/supa_email_auth.dart
@@ -221,11 +221,17 @@ class SupaEmailAuth extends StatefulWidget {
   final Widget? prefixIconEmail;
   final Widget? prefixIconPassword;
 
+  /// Icon or custom prefix widget for OTP input field
+  final Widget? prefixIconOtp;
+
   /// Whether the confirm password field should be displayed
   final bool showConfirmPasswordField;
 
   /// Whether to show snack bars
   final bool showSnackBars;
+
+  /// Whether to use OTP for password recovery instead of magic link
+  final bool useOtpForPasswordRecovery;
 
   /// {@macro supa_email_auth}
   const SupaEmailAuth({
@@ -246,8 +252,10 @@ class SupaEmailAuth extends StatefulWidget {
     this.isInitiallySigningIn = true,
     this.prefixIconEmail = const Icon(Icons.email),
     this.prefixIconPassword = const Icon(Icons.lock),
+    this.prefixIconOtp = const Icon(Icons.security),
     this.showConfirmPasswordField = false,
     this.showSnackBars = true,
+    this.useOtpForPasswordRecovery = false,
   });
 
   @override
@@ -270,6 +278,18 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
   /// Focus node for email field
   final FocusNode _emailFocusNode = FocusNode();
 
+  /// Controller for OTP input field
+  final _otpController = TextEditingController();
+
+  /// Controller for new password input field
+  final _newPasswordController = TextEditingController();
+
+  /// Controller for confirm new password input field
+  final _confirmNewPasswordController = TextEditingController();
+
+  /// Whether the user is entering OTP code
+  bool _isEnteringOtp = false;
+
   @override
   void initState() {
     super.initState();
@@ -289,6 +309,9 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
     _emailController.dispose();
     _passwordController.dispose();
     _confirmPasswordController.dispose();
+    _otpController.dispose();
+    _newPasswordController.dispose();
+    _confirmNewPasswordController.dispose();
     for (final controller in _metadataControllers.values) {
       if (controller is TextEditingController) {
         controller.dispose();
@@ -507,10 +530,59 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
             ],
             if (_isSigningIn && _isRecoveringPassword) ...[
               spacer(16),
-              ElevatedButton(
-                onPressed: _passwordRecovery,
-                child: Text(localization.sendPasswordReset),
-              ),
+              if (!_isEnteringOtp) ...[
+                ElevatedButton(
+                  onPressed: _passwordRecovery,
+                  child: Text(localization.sendPasswordReset),
+                ),
+              ] else ...[
+                TextFormField(
+                  controller: _otpController,
+                  decoration: InputDecoration(
+                    label: Text(localization.enterOtpCode),
+                    prefixIcon: widget.prefixIconOtp,
+                  ),
+                  keyboardType: TextInputType.number,
+                ),
+                spacer(16),
+                TextFormField(
+                  controller: _newPasswordController,
+                  decoration: InputDecoration(
+                    label: Text(localization.enterNewPassword),
+                    prefixIcon: widget.prefixIconPassword,
+                  ),
+                  obscureText: true,
+                  validator: widget.passwordValidator ??
+                      (value) {
+                        if (value == null ||
+                            value.isEmpty ||
+                            value.length < 6) {
+                          return localization.passwordLengthError;
+                        }
+                        return null;
+                      },
+                ),
+                spacer(16),
+                TextFormField(
+                  controller: _confirmNewPasswordController,
+                  decoration: InputDecoration(
+                    label: Text(localization.confirmPassword),
+                    prefixIcon: widget.prefixIconPassword,
+                  ),
+                  obscureText: true,
+                  validator: (value) {
+                    if (value != _newPasswordController.text) {
+                      return localization.confirmPasswordError;
+                    }
+                    return null;
+                  },
+                ),
+                spacer(16),
+                ElevatedButton(
+                  onPressed: _verifyOtpAndResetPassword,
+                  child: Text(localization.changePassword),
+                ),
+              ],
               spacer(16),
               TextButton(
                 onPressed: () {
@@ -601,18 +673,82 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
       });
 
       final email = _emailController.text.trim();
-      await supabase.auth.resetPasswordForEmail(
-        email,
-        redirectTo: widget.resetPasswordRedirectTo ?? widget.redirectTo,
+
+      if (widget.useOtpForPasswordRecovery) {
+        await supabase.auth.resetPasswordForEmail(
+          email,
+          redirectTo: widget.resetPasswordRedirectTo ?? widget.redirectTo,
+        );
+        if (!mounted) return;
+        context.showSnackBar(widget.localization.passwordResetSent);
+        setState(() {
+          _isEnteringOtp = true;
+        });
+      } else {
+        await supabase.auth.resetPasswordForEmail(
+          email,
+          redirectTo: widget.resetPasswordRedirectTo ?? widget.redirectTo,
+        );
+        widget.onPasswordResetEmailSent?.call(email);
+        if (!mounted) return;
+        context.showSnackBar(widget.localization.passwordResetSent);
+        setState(() {
+          _isRecoveringPassword = false;
+        });
+      }
+    } on AuthException catch (error) {
+      widget.onError?.call(error);
+    } catch (error) {
+      widget.onError?.call(error);
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  void _verifyOtpAndResetPassword() async {
+    try {
+      if (!_formKey.currentState!.validate()) {
+        return;
+      }
+
+      setState(() {
+        _isLoading = true;
+      });
+
+      try {
+        await supabase.auth.verifyOTP(
+          type: OtpType.recovery,
+          email: _emailController.text.trim(),
+          token: _otpController.text.trim(),
+        );
+      } on AuthException catch (error) {
+        if (error.code == 'otp_expired') {
+          if (!mounted) return;
+          context.showErrorSnackBar(widget.localization.otpCodeError);
+          return;
+        } else if (error.code == 'otp_disabled') {
+          if (!mounted) return;
+          context.showErrorSnackBar(widget.localization.otpDisabledError);
+          return;
+        }
+        rethrow;
+      }
+
+      await supabase.auth.updateUser(
+        UserAttributes(password: _newPasswordController.text),
       );
-      widget.onPasswordResetEmailSent?.call(email);
-      // FIX use_build_context_synchronously
+
       if (!mounted) return;
       if (widget.showSnackBars) {
-        context.showSnackBar(widget.localization.passwordResetSent);
+        context.showSnackBar(widget.localization.passwordChangedSuccess);
       }
       setState(() {
         _isRecoveringPassword = false;
+        _isEnteringOtp = false;
       });
     } on AuthException catch (error) {
       widget.onError?.call(error);

--- a/lib/src/components/supa_socials_auth.dart
+++ b/lib/src/components/supa_socials_auth.dart
@@ -178,13 +178,8 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
 
     final googleUser = await googleSignIn.authenticate();
     final googleAuth = googleUser.authentication;
-    final accessToken = googleAuth.idToken;
     final idToken = googleAuth.idToken;
 
-    if (accessToken == null) {
-      throw const AuthException(
-          'No Access Token found from Google sign in result.');
-    }
     if (idToken == null) {
       throw const AuthException(
           'No ID Token found from Google sign in result.');
@@ -193,7 +188,6 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
     return supabase.auth.signInWithIdToken(
       provider: OAuthProvider.google,
       idToken: idToken,
-      accessToken: accessToken,
     );
   }
 

--- a/lib/src/components/supa_socials_auth.dart
+++ b/lib/src/components/supa_socials_auth.dart
@@ -170,14 +170,15 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
     required String? webClientId,
     required String? iosClientId,
   }) async {
-    final GoogleSignIn googleSignIn = GoogleSignIn(
+    final GoogleSignIn googleSignIn = GoogleSignIn.instance;
+    await googleSignIn.initialize(
       clientId: iosClientId,
       serverClientId: webClientId,
     );
 
-    final googleUser = await googleSignIn.signIn();
-    final googleAuth = await googleUser!.authentication;
-    final accessToken = googleAuth.accessToken;
+    final googleUser = await googleSignIn.authenticate();
+    final googleAuth = googleUser.authentication;
+    final accessToken = googleAuth.idToken;
     final idToken = googleAuth.idToken;
 
     if (accessToken == null) {
@@ -229,7 +230,7 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
     _gotrueSubscription =
         Supabase.instance.client.auth.onAuthStateChange.listen((data) {
       final session = data.session;
-      if (session != null && mounted) {
+      if (session != null && mounted && session.user.isAnonymous != true) {
         widget.onSuccess.call(session);
         if (widget.showSnackBars && widget.showSuccessSnackBar) {
           context.showSnackBar(localization.successSignInMessage);

--- a/lib/src/localizations/supa_email_auth_localization.dart
+++ b/lib/src/localizations/supa_email_auth_localization.dart
@@ -15,6 +15,12 @@ class SupaEmailAuthLocalization {
   final String requiredFieldError;
   final String confirmPasswordError;
   final String confirmPassword;
+  final String enterOtpCode;
+  final String enterNewPassword;
+  final String changePassword;
+  final String passwordChangedSuccess;
+  final String otpCodeError;
+  final String otpDisabledError;
 
   const SupaEmailAuthLocalization({
     this.enterEmail = 'Enter your email',
@@ -34,5 +40,11 @@ class SupaEmailAuthLocalization {
     this.requiredFieldError = 'This field is required',
     this.confirmPasswordError = 'Passwords do not match',
     this.confirmPassword = 'Confirm Password',
+    this.enterOtpCode = 'Enter OTP code',
+    this.enterNewPassword = 'Enter new password',
+    this.changePassword = 'Change Password',
+    this.passwordChangedSuccess = 'Password successfully updated',
+    this.otpCodeError = 'Invalid OTP code',
+    this.otpDisabledError = 'OTP disabled',
   });
 }

--- a/lib/supabase_auth_ui.dart
+++ b/lib/supabase_auth_ui.dart
@@ -1,5 +1,3 @@
-library supabase_auth_ui;
-
 export 'src/components/supa_email_auth.dart';
 export 'src/components/supa_magic_auth.dart';
 export 'src/components/supa_reset_password.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   supabase_flutter: ^2.5.6
   email_validator: ^2.0.1
   font_awesome_flutter: ^10.6.0
-  google_sign_in: ^6.2.1
+  google_sign_in: ^7.2.0
   sign_in_with_apple: ^6.1.0
   crypto: ^3.0.3
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Currently, the password recovery system only supports magic link reset via email. Users receive an email with a link to reset their password.

## What is the new behavior?

- Adds option to use OTP (One-Time Password) for password recovery
- New flow includes:
  - User requests password reset with their email
  - User receives OTP code via email
  - User enters OTP code and new password with confirmation
  - Password is updated after successful OTP verification
- Added new localizations for OTP-related messages
- Added customizable OTP input icon
- Added password confirmation field with validation
- Added proper error handling for invalid OTP codes

## Additional context
![image](https://github.com/user-attachments/assets/d278c24d-d39b-4b68-9c87-feec7ac02a40)
