### PR TITLE
provide minimum google authentication scope

### DIFF
--- a/lib/src/components/supa_socials_auth.dart
+++ b/lib/src/components/supa_socials_auth.dart
@@ -158,9 +158,15 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
     required String? webClientId,
     required String? iosClientId,
   }) async {
+    final scopes = widget.scopes != null
+        ? widget.scopes![OAuthProvider.google]?.split(',')
+        : null;
+
     final GoogleSignIn googleSignIn = GoogleSignIn(
       clientId: iosClientId,
       serverClientId: webClientId,
+      // These default values ['email', 'profile'] are needed as to gogole authenitcation recent update
+      scopes: scopes ?? ['email', 'profile'],
     );
 
     final googleUser = await googleSignIn.signIn();


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Fix a bug not be able to authenticate using Google account

## What is the current behavior?

- Google throws Exception about lacking logging in scope due to recent Google authentication update

## What is the new behavior?

- The bare minimum required scope are ['email', 'profile'] for logging in were added, now can authenticate with Google again
