### PR TITLE
feat: add autofocus option to SupaEmailAuth

### DIFF
--- a/lib/src/components/supa_email_auth.dart
+++ b/lib/src/components/supa_email_auth.dart
@@ -159,6 +159,9 @@ typedef MetadataController = Object;
 /// ```
 /// {@endtemplate}
 class SupaEmailAuth extends StatefulWidget {
+  /// Whether the email field should automatically focus when the form is shown
+  final bool autofocus;
+
   /// The URL to redirect the user to when clicking on the link on the
   /// confirmation link after signing up.
   final String? redirectTo;
@@ -220,6 +223,7 @@ class SupaEmailAuth extends StatefulWidget {
   /// {@macro supa_email_auth}
   const SupaEmailAuth({
     super.key,
+    this.autofocus = false,
     this.redirectTo,
     this.resetPasswordRedirectTo,
     this.passwordValidator,
@@ -298,7 +302,7 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
               keyboardType: TextInputType.emailAddress,
               autofillHints: const [AutofillHints.email],
               autovalidateMode: AutovalidateMode.onUserInteraction,
-              autofocus: true,
+              autofocus: widget.autofocus,
               focusNode: _emailFocusNode,
               textInputAction: _isRecoveringPassword
                   ? TextInputAction.done


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

The email field is always focused when the form is displayed, which may not be desired in all cases.

## What is the new behavior?

Adds an `autofocus` parameter to `SupaEmailAuth` to let developers control whether the email input field should be auto-focused on initial render.

The default value is `true`, maintaining the original behavior unless explicitly changed.

## Additional context

This improves flexibility for customizing user experience, especially on mobile.
Developers can now prevent the keyboard from popping up automatically by setting `autofocus: false`.