### PR TITLE
fix: Call onToggleRecoverPassword(false) on “Back to sign in”

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - feat: Add a show/hide visibility toggle to password fields [#149](https://github.com/supabase-community/flutter-auth-ui/pull/149)
 - feat: Add showSnackBars option to make snack bars optional across all auth components [#150](https://github.com/supabase-community/flutter-auth-ui/pull/150)
 - feat: Add password recovery with OTP to SupaEmailAuth [#130](https://github.com/supabase-community/flutter-auth-ui/pull/130)
+- fix: Call `onToggleRecoverPassword(false)` when leaving the password recovery view [#148](https://github.com/supabase-community/flutter-auth-ui/pull/148)
 
 ## 0.5.5
 

--- a/lib/src/components/supa_email_auth.dart
+++ b/lib/src/components/supa_email_auth.dart
@@ -596,6 +596,7 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                     _isRecoveringPassword = false;
                     _isEnteringOtp = false;
                   });
+                  widget.onToggleRecoverPassword?.call(_isRecoveringPassword);
                 },
                 child: Text(localization.backToSignIn),
               ),

--- a/lib/src/components/supa_email_auth.dart
+++ b/lib/src/components/supa_email_auth.dart
@@ -698,6 +698,9 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
           _isRecoveringPassword = false;
         }
       });
+      if (!widget.useOtpForPasswordRecovery) {
+        widget.onToggleRecoverPassword?.call(_isRecoveringPassword);
+      }
     } on AuthException catch (error) {
       widget.onError?.call(error);
     } catch (error) {
@@ -752,6 +755,7 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
         _isRecoveringPassword = false;
         _isEnteringOtp = false;
       });
+      widget.onToggleRecoverPassword?.call(_isRecoveringPassword);
     } on AuthException catch (error) {
       widget.onError?.call(error);
     } catch (error) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

- Tapping “Forgot password” correctly triggers `onToggleRecoverPassword(true)`.
- Tapping “Back to sign in” does not trigger `onToggleRecoverPassword(false)`.
- As a result, parent widgets relying on this callback remain stuck in the “Recover Password” state (e.g., titles or layouts don’t update back).

Related issue: Fixes #147 

## What is the new behavior?

- Tapping “Back to sign in” now triggers onToggleRecoverPassword(false) after the internal state switches back from recovery, keeping parent UI in sync.
- Entering the recovery flow via “Forgot password” continues to trigger onToggleRecoverPassword(true) as before.
- Parent widgets relying on this callback (e.g., to update titles/layout) immediately reflect the correct state when leaving the password recovery view.
- No breaking changes; existing onToggleSignIn behavior remains unchanged.

## Additional context

- No breaking changes.
- Minimal patch touching only the callback invocation on the “Back to sign in” action.
- Tested manually on mobile and web; no performance implications expected.

