### PR TITLE
feat: make snack bars optional across all auth components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 - BREAKING: `onPasswordResetEmailSent` now passes the email the reset was requested for, changing its signature from `void Function()?` to `void Function(String email)?` [#146](https://github.com/supabase-community/flutter-auth-ui/pull/146)
 - feat: Add a show/hide visibility toggle to password fields [#149](https://github.com/supabase-community/flutter-auth-ui/pull/149)
+- feat: Add showSnackBars option to make snack bars optional in SupaEmailAuth and SupaResetPassword [#150](https://github.com/supabase-community/flutter-auth-ui/pull/150)
 
 ## 0.5.5
 
 - feat: Add Confirm Password Field to SupaEmailAuth Component for Sign-Up Process [#129](https://github.com/supabase-community/flutter-auth-ui/pull/129)
 - feat: Add autofocus option to SupaEmailAuth [#139](https://github.com/supabase-community/flutter-auth-ui/pull/139)
-- feat: Add showSnackBars option to make snack bars optional in SupaEmailAuth and SupaResetPassword [#150](https://github.com/supabase-community/flutter-auth-ui/pull/150)
 
 ## 0.5.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - feat: Add Confirm Password Field to SupaEmailAuth Component for Sign-Up Process [#129](https://github.com/supabase-community/flutter-auth-ui/pull/129)
 - feat: Add autofocus option to SupaEmailAuth [#139](https://github.com/supabase-community/flutter-auth-ui/pull/139)
+- feat: Add showSnackBars option to make snack bars optional in SupaEmailAuth and SupaResetPassword [#150](https://github.com/supabase-community/flutter-auth-ui/pull/150)
 
 ## 0.5.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - BREAKING: `onPasswordResetEmailSent` now passes the email the reset was requested for, changing its signature from `void Function()?` to `void Function(String email)?` [#146](https://github.com/supabase-community/flutter-auth-ui/pull/146)
 - feat: Add a show/hide visibility toggle to password fields [#149](https://github.com/supabase-community/flutter-auth-ui/pull/149)
-- feat: Add showSnackBars option to make snack bars optional in SupaEmailAuth and SupaResetPassword [#150](https://github.com/supabase-community/flutter-auth-ui/pull/150)
+- feat: Add showSnackBars option to make snack bars optional across all auth components [#150](https://github.com/supabase-community/flutter-auth-ui/pull/150)
 
 ## 0.5.5
 

--- a/lib/src/components/supa_email_auth.dart
+++ b/lib/src/components/supa_email_auth.dart
@@ -224,6 +224,9 @@ class SupaEmailAuth extends StatefulWidget {
   /// Whether the confirm password field should be displayed
   final bool showConfirmPasswordField;
 
+  /// whether to show snack bars
+  final bool showSnacks;
+
   /// {@macro supa_email_auth}
   const SupaEmailAuth({
     super.key,
@@ -244,6 +247,7 @@ class SupaEmailAuth extends StatefulWidget {
     this.prefixIconEmail = const Icon(Icons.email),
     this.prefixIconPassword = const Icon(Icons.lock),
     this.showConfirmPasswordField = false,
+    this.showSnacks = true,
   });
 
   @override
@@ -564,15 +568,19 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
       }
     } on AuthException catch (error) {
       if (widget.onError == null && mounted) {
-        context.showErrorSnackBar(error.message);
+        if (widget.showSnacks) {
+          context.showErrorSnackBar(error.message);
+        }
       } else {
         widget.onError?.call(error);
       }
       _emailFocusNode.requestFocus();
     } catch (error) {
       if (widget.onError == null && mounted) {
-        context.showErrorSnackBar(
-            '${widget.localization.unexpectedError}: $error');
+        if (widget.showSnacks) {
+          context.showErrorSnackBar(
+              '${widget.localization.unexpectedError}: $error');
+        }
       } else {
         widget.onError?.call(error);
       }
@@ -604,7 +612,9 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
       widget.onPasswordResetEmailSent?.call(email);
       // FIX use_build_context_synchronously
       if (!mounted) return;
-      context.showSnackBar(widget.localization.passwordResetSent);
+      if (widget.showSnacks) {
+        context.showSnackBar(widget.localization.passwordResetSent);
+      }
       setState(() {
         _isRecoveringPassword = false;
       });

--- a/lib/src/components/supa_email_auth.dart
+++ b/lib/src/components/supa_email_auth.dart
@@ -224,8 +224,8 @@ class SupaEmailAuth extends StatefulWidget {
   /// Whether the confirm password field should be displayed
   final bool showConfirmPasswordField;
 
-  /// whether to show snack bars
-  final bool showSnacks;
+  /// Whether to show snack bars
+  final bool showSnackBars;
 
   /// {@macro supa_email_auth}
   const SupaEmailAuth({
@@ -247,7 +247,7 @@ class SupaEmailAuth extends StatefulWidget {
     this.prefixIconEmail = const Icon(Icons.email),
     this.prefixIconPassword = const Icon(Icons.lock),
     this.showConfirmPasswordField = false,
-    this.showSnacks = true,
+    this.showSnackBars = true,
   });
 
   @override
@@ -567,20 +567,16 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
         widget.onSignUpComplete.call(response);
       }
     } on AuthException catch (error) {
-      if (widget.onError == null && mounted) {
-        if (widget.showSnacks) {
-          context.showErrorSnackBar(error.message);
-        }
+      if (widget.onError == null && widget.showSnackBars && mounted) {
+        context.showErrorSnackBar(error.message);
       } else {
         widget.onError?.call(error);
       }
       _emailFocusNode.requestFocus();
     } catch (error) {
-      if (widget.onError == null && mounted) {
-        if (widget.showSnacks) {
-          context.showErrorSnackBar(
-              '${widget.localization.unexpectedError}: $error');
-        }
+      if (widget.onError == null && widget.showSnackBars && mounted) {
+        context.showErrorSnackBar(
+            '${widget.localization.unexpectedError}: $error');
       } else {
         widget.onError?.call(error);
       }
@@ -612,7 +608,7 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
       widget.onPasswordResetEmailSent?.call(email);
       // FIX use_build_context_synchronously
       if (!mounted) return;
-      if (widget.showSnacks) {
+      if (widget.showSnackBars) {
         context.showSnackBar(widget.localization.passwordResetSent);
       }
       setState(() {

--- a/lib/src/components/supa_magic_auth.dart
+++ b/lib/src/components/supa_magic_auth.dart
@@ -19,6 +19,9 @@ class SupaMagicAuth extends StatefulWidget {
   /// Method to be called when the auth action threw an excepction
   final void Function(Object error)? onError;
 
+  /// Whether to show snack bars
+  final bool showSnackBars;
+
   /// Localization for the form
   final SupaMagicAuthLocalization localization;
 
@@ -27,6 +30,7 @@ class SupaMagicAuth extends StatefulWidget {
     this.redirectUrl,
     required this.onSuccess,
     this.onError,
+    this.showSnackBars = true,
     this.localization = const SupaMagicAuthLocalization(),
   });
 
@@ -112,17 +116,21 @@ class _SupaMagicAuthState extends State<SupaMagicAuth> {
                   email: _email.text,
                   emailRedirectTo: widget.redirectUrl,
                 );
-                if (context.mounted) {
+                if (widget.showSnackBars && context.mounted) {
                   context.showSnackBar(localization.checkYourEmail);
                 }
               } on AuthException catch (error) {
-                if (widget.onError == null && context.mounted) {
+                if (widget.onError == null &&
+                    widget.showSnackBars &&
+                    context.mounted) {
                   context.showErrorSnackBar(error.message);
                 } else {
                   widget.onError?.call(error);
                 }
               } catch (error) {
-                if (widget.onError == null && context.mounted) {
+                if (widget.onError == null &&
+                    widget.showSnackBars &&
+                    context.mounted) {
                   context.showErrorSnackBar(
                       '${localization.unexpectedError}: $error');
                 } else {

--- a/lib/src/components/supa_phone_auth.dart
+++ b/lib/src/components/supa_phone_auth.dart
@@ -14,6 +14,9 @@ class SupaPhoneAuth extends StatefulWidget {
   /// Method to be called when the auth action threw an exception
   final void Function(Object error)? onError;
 
+  /// Whether to show snack bars
+  final bool showSnackBars;
+
   /// Localization for the form
   final SupaPhoneAuthLocalization localization;
 
@@ -22,6 +25,7 @@ class SupaPhoneAuth extends StatefulWidget {
     required this.authAction,
     required this.onSuccess,
     this.onError,
+    this.showSnackBars = true,
     this.localization = const SupaPhoneAuthLocalization(),
   });
 
@@ -124,13 +128,17 @@ class _SupaPhoneAuthState extends State<SupaPhoneAuth> {
                     widget.onSuccess(response);
                   }
                 } on AuthException catch (error) {
-                  if (widget.onError == null && context.mounted) {
+                  if (widget.onError == null &&
+                      widget.showSnackBars &&
+                      context.mounted) {
                     context.showErrorSnackBar(error.message);
                   } else {
                     widget.onError?.call(error);
                   }
                 } catch (error) {
-                  if (widget.onError == null && context.mounted) {
+                  if (widget.onError == null &&
+                      widget.showSnackBars &&
+                      context.mounted) {
                     context.showErrorSnackBar(
                         '${localization.unexpectedError}: $error');
                   } else {

--- a/lib/src/components/supa_reset_password.dart
+++ b/lib/src/components/supa_reset_password.dart
@@ -9,6 +9,9 @@ class SupaResetPassword extends StatefulWidget {
   /// accessToken of the user
   final String? accessToken;
 
+  /// whether to show snack bars
+  final bool showSnacks;
+
   /// Method to be called when the auth action is success
   final void Function(UserResponse response) onSuccess;
 
@@ -21,6 +24,7 @@ class SupaResetPassword extends StatefulWidget {
   const SupaResetPassword({
     super.key,
     this.accessToken,
+    this.showSnacks = true,
     required this.onSuccess,
     this.onError,
     this.localization = const SupaResetPasswordLocalization(),
@@ -72,14 +76,14 @@ class _SupaResetPasswordState extends State<SupaResetPassword> {
               }
               try {
                 final response = await supabase.auth.updateUser(
-                  UserAttributes(
-                    password: _password.text,
-                  ),
+                  UserAttributes(password: _password.text),
                 );
                 widget.onSuccess.call(response);
                 // FIX use_build_context_synchronously
                 if (!context.mounted) return;
-                context.showSnackBar(localization.passwordResetSent);
+                if (widget.showSnacks) {
+                  context.showSnackBar(localization.passwordResetSent);
+                }
               } on AuthException catch (error) {
                 if (widget.onError == null && context.mounted) {
                   context.showErrorSnackBar(error.message);
@@ -89,7 +93,8 @@ class _SupaResetPasswordState extends State<SupaResetPassword> {
               } catch (error) {
                 if (widget.onError == null && context.mounted) {
                   context.showErrorSnackBar(
-                      '${localization.passwordLengthError}: $error');
+                    '${localization.passwordLengthError}: $error',
+                  );
                 } else {
                   widget.onError?.call(error);
                 }

--- a/lib/src/components/supa_reset_password.dart
+++ b/lib/src/components/supa_reset_password.dart
@@ -9,8 +9,8 @@ class SupaResetPassword extends StatefulWidget {
   /// accessToken of the user
   final String? accessToken;
 
-  /// whether to show snack bars
-  final bool showSnacks;
+  /// Whether to show snack bars
+  final bool showSnackBars;
 
   /// Method to be called when the auth action is success
   final void Function(UserResponse response) onSuccess;
@@ -24,7 +24,7 @@ class SupaResetPassword extends StatefulWidget {
   const SupaResetPassword({
     super.key,
     this.accessToken,
-    this.showSnacks = true,
+    this.showSnackBars = true,
     required this.onSuccess,
     this.onError,
     this.localization = const SupaResetPasswordLocalization(),
@@ -81,17 +81,21 @@ class _SupaResetPasswordState extends State<SupaResetPassword> {
                 widget.onSuccess.call(response);
                 // FIX use_build_context_synchronously
                 if (!context.mounted) return;
-                if (widget.showSnacks) {
+                if (widget.showSnackBars) {
                   context.showSnackBar(localization.passwordResetSent);
                 }
               } on AuthException catch (error) {
-                if (widget.onError == null && context.mounted) {
+                if (widget.onError == null &&
+                    widget.showSnackBars &&
+                    context.mounted) {
                   context.showErrorSnackBar(error.message);
                 } else {
                   widget.onError?.call(error);
                 }
               } catch (error) {
-                if (widget.onError == null && context.mounted) {
+                if (widget.onError == null &&
+                    widget.showSnackBars &&
+                    context.mounted) {
                   context.showErrorSnackBar(
                     '${localization.passwordLengthError}: $error',
                   );

--- a/lib/src/components/supa_socials_auth.dart
+++ b/lib/src/components/supa_socials_auth.dart
@@ -119,7 +119,12 @@ class SupaSocialsAuth extends StatefulWidget {
   /// Method to be called when the auth action threw an excepction
   final void Function(Object error)? onError;
 
+  /// Whether to show snack bars
+  final bool showSnackBars;
+
   /// Whether to show a SnackBar after a successful sign in
+  ///
+  /// Has no effect when [showSnackBars] is `false`.
   final bool showSuccessSnackBar;
 
   /// OpenID scope(s) for provider authorization request (ex. '.default')
@@ -144,6 +149,7 @@ class SupaSocialsAuth extends StatefulWidget {
     required this.onSuccess,
     this.onError,
     this.socialButtonVariant = SocialButtonVariant.iconAndText,
+    this.showSnackBars = true,
     this.showSuccessSnackBar = true,
     this.scopes,
     this.queryParams,
@@ -225,7 +231,7 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
       final session = data.session;
       if (session != null && mounted) {
         widget.onSuccess.call(session);
-        if (widget.showSuccessSnackBar) {
+        if (widget.showSnackBars && widget.showSuccessSnackBar) {
           context.showSnackBar(localization.successSignInMessage);
         }
       }
@@ -366,13 +372,17 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
               authScreenLaunchMode: widget.authScreenLaunchMode,
             );
           } on AuthException catch (error) {
-            if (widget.onError == null && context.mounted) {
+            if (widget.onError == null &&
+                widget.showSnackBars &&
+                context.mounted) {
               context.showErrorSnackBar(error.message);
             } else {
               widget.onError?.call(error);
             }
           } catch (error) {
-            if (widget.onError == null && context.mounted) {
+            if (widget.onError == null &&
+                widget.showSnackBars &&
+                context.mounted) {
               context
                   .showErrorSnackBar('${localization.unexpectedError}: $error');
             } else {

--- a/lib/src/components/supa_verify_phone.dart
+++ b/lib/src/components/supa_verify_phone.dart
@@ -11,6 +11,9 @@ class SupaVerifyPhone extends StatefulWidget {
   /// Method to be called when the auth action threw an excepction
   final void Function(Object error)? onError;
 
+  /// Whether to show snack bars
+  final bool showSnackBars;
+
   /// Localization for the form
   final SupaVerifyPhoneLocalization localization;
 
@@ -18,6 +21,7 @@ class SupaVerifyPhone extends StatefulWidget {
     super.key,
     required this.onSuccess,
     this.onError,
+    this.showSnackBars = true,
     this.localization = const SupaVerifyPhoneLocalization(),
   });
 
@@ -82,13 +86,17 @@ class _SupaVerifyPhoneState extends State<SupaVerifyPhone> {
                 );
                 widget.onSuccess(response);
               } on AuthException catch (error) {
-                if (widget.onError == null && context.mounted) {
+                if (widget.onError == null &&
+                    widget.showSnackBars &&
+                    context.mounted) {
                   context.showErrorSnackBar(error.message);
                 } else {
                   widget.onError?.call(error);
                 }
               } catch (error) {
-                if (widget.onError == null && context.mounted) {
+                if (widget.onError == null &&
+                    widget.showSnackBars &&
+                    context.mounted) {
                   context.showErrorSnackBar(
                       '${localization.unexpectedErrorOccurred}: $error');
                 } else {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature: make the built-in snack bars optional so apps that show their own styled snacks (or handle feedback differently) can opt out.

## What is the current behavior?

Snack bars are always shown.

## What is the new behavior?

Every auth component now exposes a `showSnackBars` option (defaults to `true`, so behavior is unchanged unless you opt out). When set to `false`, all snack bars from that component are suppressed:

- `SupaEmailAuth`
- `SupaResetPassword`
- `SupaPhoneAuth`
- `SupaMagicAuth`
- `SupaVerifyPhone`
- `SupaSocialsAuth`

`SupaSocialsAuth` keeps its existing `showSuccessSnackBar` flag as a finer-grained control; its success snack now shows only when both `showSnackBars` and `showSuccessSnackBar` are `true`.

## Additional context

Not a breaking change: all options default to `true`.
