### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supabase_auth_ui
 description: UI library to implement auth forms using Supabase and Flutter
-version: 0.5.5
+version: 0.6.0
 homepage: https://supabase.com
 repository: 'https://github.com/supabase-community/supabase_auth_ui'
 


### PR DESCRIPTION
Bumps the package version to `0.6.0`, matching the latest entry in the CHANGELOG.

The example app uses a path dependency and the README does not pin a version, so `pubspec.yaml` is the only place that needed updating.