### PR TITLE
fix: stop gitignoring Windows CMakeLists.txt files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-*.txt
 # Miscellaneous
 *.class
 *.log


### PR DESCRIPTION
## Problem

`dart pub publish` warns that three checked-in files are ignored by a `.gitignore`:

```
example/windows/CMakeLists.txt
example/windows/flutter/CMakeLists.txt
example/windows/runner/CMakeLists.txt
```

These are part of the standard Flutter Windows runner scaffold and are required to build the Windows example, so they should stay checked in.

## Cause

The root `.gitignore` started with a spurious `*.txt` pattern that matched every `CMakeLists.txt`. It is not part of the standard Flutter `.gitignore` template.

## Fix

Removed the `*.txt` line. The files are no longer gitignored, which resolves the pub warning without needing a `.pubignore`.