### PR TITLE
fix: bump min Dart SDK to 3.9.0 and update dependencies

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:flutter_lints/flutter.yaml
+include: package:supabase_lints/analysis_options_flutter.yaml
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -7,7 +7,7 @@
 
 # The following line activates a set of recommended lints for Flutter apps,
 # packages, and plugins designed to encourage good coding practices.
-include: package:flutter_lints/flutter.yaml
+include: package:supabase_lints/analysis_options_flutter.yaml
 
 linter:
   # The lint rules applied to this project can be customized in the

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,17 +6,23 @@ import FlutterMacOS
 import Foundation
 
 import app_links
+import device_info_plus
 import google_sign_in_ios
-import path_provider_foundation
+import package_info_plus
+import passkeys_darwin
 import shared_preferences_foundation
 import sign_in_with_apple
+import ua_client_hints
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
+  DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
-  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  PasskeysPlugin.register(with: registry.registrar(forPlugin: "PasskeysPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SignInWithApplePlugin.register(with: registry.registrar(forPlugin: "SignInWithApplePlugin"))
+  UAClientHintsPlugin.register(with: registry.registrar(forPlugin: "UAClientHintsPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -6,7 +6,8 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=3.9.0 <4.0.0'
+  flutter: '>=3.35.0'
 
 dependencies:
   flutter:
@@ -18,7 +19,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  flutter_lints: ^2.0.0
+  supabase_lints: ^0.1.0
 
 flutter:
   uses-material-design: true

--- a/example/windows/flutter/generated_plugin_registrant.cc
+++ b/example/windows/flutter/generated_plugin_registrant.cc
@@ -7,11 +7,14 @@
 #include "generated_plugin_registrant.h"
 
 #include <app_links/app_links_plugin_c_api.h>
+#include <passkeys_windows/passkeys_windows_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   AppLinksPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("AppLinksPluginCApi"));
+  PasskeysWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("PasskeysWindowsPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/example/windows/flutter/generated_plugins.cmake
+++ b/example/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   app_links
+  passkeys_windows
   url_launcher_windows
 )
 

--- a/lib/src/components/supa_email_auth.dart
+++ b/lib/src/components/supa_email_auth.dart
@@ -120,9 +120,11 @@ class BooleanMetaDataField extends MetaDataField {
     this.isRequired = false,
     this.checkboxPosition = ListTileControlAffinity.platform,
     required super.key,
-  })  : assert(label != null || richLabelSpans != null,
-            'Either label or richLabelSpans must be provided'),
-        super(label: label ?? '');
+  }) : assert(
+         label != null || richLabelSpans != null,
+         'Either label or richLabelSpans must be provided',
+       ),
+       super(label: label ?? '');
 
   Widget getLabelWidget(BuildContext context) {
     // This matches the default style of [TextField], to match the other fields
@@ -314,14 +316,16 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
     _emailController.text = widget.prefilledEmail ?? '';
     _passwordController.text = widget.prefilledPassword ?? '';
     _isSigningIn = widget.isInitiallySigningIn;
-    _metadataControllers = Map.fromEntries((widget.metadataFields ?? []).map(
-      (metadataField) => MapEntry(
-        metadataField.key,
-        metadataField is BooleanMetaDataField
-            ? metadataField.value
-            : TextEditingController(),
+    _metadataControllers = Map.fromEntries(
+      (widget.metadataFields ?? []).map(
+        (metadataField) => MapEntry(
+          metadataField.key,
+          metadataField is BooleanMetaDataField
+              ? metadataField.value
+              : TextEditingController(),
+        ),
       ),
-    ));
+    );
   }
 
   @override
@@ -391,7 +395,8 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                 textInputAction: widget.metadataFields != null && !_isSigningIn
                     ? TextInputAction.next
                     : TextInputAction.done,
-                validator: widget.passwordValidator ??
+                validator:
+                    widget.passwordValidator ??
                     (value) {
                       if (value == null || value.isEmpty || value.length < 6) {
                         return localization.passwordLengthError;
@@ -422,92 +427,98 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
               spacer(16),
               if (widget.metadataFields != null && !_isSigningIn)
                 ...widget.metadataFields!
-                    .map((metadataField) => [
-                          // Render a Checkbox that displays an error message
-                          // beneath it if the field is required and the user
-                          // hasn't checked it when submitting the form.
-                          if (metadataField is BooleanMetaDataField)
-                            FormField<bool>(
-                              validator: metadataField.isRequired
-                                  ? (bool? value) {
-                                      if (value != true) {
-                                        return localization.requiredFieldError;
-                                      }
-                                      return null;
+                    .map(
+                      (metadataField) => [
+                        // Render a Checkbox that displays an error message
+                        // beneath it if the field is required and the user
+                        // hasn't checked it when submitting the form.
+                        if (metadataField is BooleanMetaDataField)
+                          FormField<bool>(
+                            validator: metadataField.isRequired
+                                ? (bool? value) {
+                                    if (value != true) {
+                                      return localization.requiredFieldError;
                                     }
-                                  : null,
-                              builder: (FormFieldState<bool> field) {
-                                final theme = Theme.of(context);
+                                    return null;
+                                  }
+                                : null,
+                            builder: (FormFieldState<bool> field) {
+                              final theme = Theme.of(context);
 
-                                return Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    CheckboxListTile(
-                                      title:
-                                          metadataField.getLabelWidget(context),
-                                      value: _metadataControllers[
-                                          metadataField.key] as bool,
-                                      onChanged: (bool? value) {
-                                        setState(() {
-                                          _metadataControllers[metadataField
-                                              .key] = value ?? false;
-                                        });
-                                        field.didChange(value);
-                                      },
-                                      checkboxSemanticLabel:
-                                          metadataField.checkboxSemanticLabel,
-                                      controlAffinity:
-                                          metadataField.checkboxPosition,
-                                      contentPadding:
-                                          const EdgeInsets.symmetric(
-                                              horizontal: 4.0),
+                              return Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  CheckboxListTile(
+                                    title: metadataField.getLabelWidget(
+                                      context,
                                     ),
-                                    if (field.hasError)
-                                      Padding(
-                                        padding: const EdgeInsets.only(
-                                            left: 16, top: 4),
-                                        child: Text(
-                                          field.errorText!,
-                                          style: theme.textTheme.labelSmall
-                                              ?.copyWith(
-                                            color: theme.colorScheme.error,
-                                          ),
-                                        ),
+                                    value:
+                                        _metadataControllers[metadataField.key]
+                                            as bool,
+                                    onChanged: (bool? value) {
+                                      setState(() {
+                                        _metadataControllers[metadataField
+                                                .key] =
+                                            value ?? false;
+                                      });
+                                      field.didChange(value);
+                                    },
+                                    checkboxSemanticLabel:
+                                        metadataField.checkboxSemanticLabel,
+                                    controlAffinity:
+                                        metadataField.checkboxPosition,
+                                    contentPadding: const EdgeInsets.symmetric(
+                                      horizontal: 4.0,
+                                    ),
+                                  ),
+                                  if (field.hasError)
+                                    Padding(
+                                      padding: const EdgeInsets.only(
+                                        left: 16,
+                                        top: 4,
                                       ),
-                                  ],
-                                );
-                              },
-                            )
-                          else
-                            // Otherwise render a normal TextFormField matching
-                            // the style of the other fields in the form.
-                            TextFormField(
-                              controller:
-                                  _metadataControllers[metadataField.key]
-                                      as TextEditingController,
-                              textInputAction:
-                                  widget.metadataFields!.last == metadataField
-                                      ? TextInputAction.done
-                                      : TextInputAction.next,
-                              decoration: InputDecoration(
-                                label: Text(metadataField.label),
-                                prefixIcon: metadataField.prefixIcon,
-                              ),
-                              validator: metadataField.validator,
-                              autovalidateMode:
-                                  AutovalidateMode.onUserInteraction,
-                              onFieldSubmitted: (_) {
-                                if (metadataField !=
-                                    widget.metadataFields!.last) {
-                                  FocusScope.of(context).nextFocus();
-                                } else if (widget
-                                    .enableAutomaticFormSubmission) {
-                                  _signInSignUp();
-                                }
-                              },
+                                      child: Text(
+                                        field.errorText!,
+                                        style: theme.textTheme.labelSmall
+                                            ?.copyWith(
+                                              color: theme.colorScheme.error,
+                                            ),
+                                      ),
+                                    ),
+                                ],
+                              );
+                            },
+                          )
+                        else
+                          // Otherwise render a normal TextFormField matching
+                          // the style of the other fields in the form.
+                          TextFormField(
+                            controller:
+                                _metadataControllers[metadataField.key]
+                                    as TextEditingController,
+                            textInputAction:
+                                widget.metadataFields!.last == metadataField
+                                ? TextInputAction.done
+                                : TextInputAction.next,
+                            decoration: InputDecoration(
+                              label: Text(metadataField.label),
+                              prefixIcon: metadataField.prefixIcon,
                             ),
-                          spacer(16),
-                        ])
+                            validator: metadataField.validator,
+                            autovalidateMode:
+                                AutovalidateMode.onUserInteraction,
+                            onFieldSubmitted: (_) {
+                              if (metadataField !=
+                                  widget.metadataFields!.last) {
+                                FocusScope.of(context).nextFocus();
+                              } else if (widget.enableAutomaticFormSubmission) {
+                                _signInSignUp();
+                              }
+                            },
+                          ),
+                        spacer(16),
+                      ],
+                    )
                     .expand((element) => element),
               ElevatedButton(
                 onPressed: _signInSignUp,
@@ -520,9 +531,11 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                           strokeWidth: 1.5,
                         ),
                       )
-                    : Text(_isSigningIn
-                        ? localization.signIn
-                        : localization.signUp),
+                    : Text(
+                        _isSigningIn
+                            ? localization.signIn
+                            : localization.signUp,
+                      ),
               ),
               spacer(16),
               if (_isSigningIn) ...[
@@ -546,9 +559,11 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                   widget.onToggleSignIn?.call(_isSigningIn);
                   widget.onToggleRecoverPassword?.call(_isRecoveringPassword);
                 },
-                child: Text(_isSigningIn
-                    ? localization.dontHaveAccount
-                    : localization.haveAccount),
+                child: Text(
+                  _isSigningIn
+                      ? localization.dontHaveAccount
+                      : localization.haveAccount,
+                ),
               ),
             ],
             if (_isSigningIn && _isRecoveringPassword) ...[
@@ -583,7 +598,8 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                   ),
                   obscureText: true,
                   textInputAction: TextInputAction.next,
-                  validator: widget.passwordValidator ??
+                  validator:
+                      widget.passwordValidator ??
                       (value) {
                         if (value == null ||
                             value.isEmpty ||
@@ -687,7 +703,8 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
     } catch (error) {
       if (widget.onError == null && widget.showSnackBars && mounted) {
         context.showErrorSnackBar(
-            '${widget.localization.unexpectedError}: $error');
+          '${widget.localization.unexpectedError}: $error',
+        );
       } else {
         widget.onError?.call(error);
       }
@@ -812,10 +829,15 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
 
   /// Resolve the user_metadata coming from the metadataFields
   Map<String, dynamic> _resolveMetadataFieldsData() {
-    return Map.fromEntries(_metadataControllers.entries.map((entry) => MapEntry(
-        entry.key,
-        entry.value is TextEditingController
-            ? (entry.value as TextEditingController).text
-            : entry.value)));
+    return Map.fromEntries(
+      _metadataControllers.entries.map(
+        (entry) => MapEntry(
+          entry.key,
+          entry.value is TextEditingController
+              ? (entry.value as TextEditingController).text
+              : entry.value,
+        ),
+      ),
+    );
   }
 }

--- a/lib/src/components/supa_magic_auth.dart
+++ b/lib/src/components/supa_magic_auth.dart
@@ -58,13 +58,13 @@ class _SupaMagicAuthState extends State<SupaMagicAuth> {
   @override
   void initState() {
     super.initState();
-    _gotrueSubscription =
-        Supabase.instance.client.auth.onAuthStateChange.listen((data) {
-      final session = data.session;
-      if (session != null && mounted) {
-        widget.onSuccess(session);
-      }
-    });
+    _gotrueSubscription = Supabase.instance.client.auth.onAuthStateChange
+        .listen((data) {
+          final session = data.session;
+          if (session != null && mounted) {
+            widget.onSuccess(session);
+          }
+        });
   }
 
   @override

--- a/lib/src/components/supa_socials_auth.dart
+++ b/lib/src/components/supa_socials_auth.dart
@@ -14,49 +14,49 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 extension on OAuthProvider {
   FaIconData get iconData => switch (this) {
-        OAuthProvider.apple => FontAwesomeIcons.apple,
-        OAuthProvider.azure => FontAwesomeIcons.microsoft,
-        OAuthProvider.bitbucket => FontAwesomeIcons.bitbucket,
-        OAuthProvider.discord => FontAwesomeIcons.discord,
-        OAuthProvider.facebook => FontAwesomeIcons.facebook,
-        OAuthProvider.figma => FontAwesomeIcons.figma,
-        OAuthProvider.github => FontAwesomeIcons.github,
-        OAuthProvider.gitlab => FontAwesomeIcons.gitlab,
-        OAuthProvider.google => FontAwesomeIcons.google,
-        OAuthProvider.linkedin => FontAwesomeIcons.linkedin,
-        OAuthProvider.linkedinOidc => FontAwesomeIcons.linkedin,
-        OAuthProvider.slack => FontAwesomeIcons.slack,
-        OAuthProvider.slackOidc => FontAwesomeIcons.slack,
-        OAuthProvider.spotify => FontAwesomeIcons.spotify,
-        OAuthProvider.twitch => FontAwesomeIcons.twitch,
-        OAuthProvider.twitter => FontAwesomeIcons.xTwitter,
-        _ => FontAwesomeIcons.xmark,
-      };
+    OAuthProvider.apple => FontAwesomeIcons.apple,
+    OAuthProvider.azure => FontAwesomeIcons.microsoft,
+    OAuthProvider.bitbucket => FontAwesomeIcons.bitbucket,
+    OAuthProvider.discord => FontAwesomeIcons.discord,
+    OAuthProvider.facebook => FontAwesomeIcons.facebook,
+    OAuthProvider.figma => FontAwesomeIcons.figma,
+    OAuthProvider.github => FontAwesomeIcons.github,
+    OAuthProvider.gitlab => FontAwesomeIcons.gitlab,
+    OAuthProvider.google => FontAwesomeIcons.google,
+    OAuthProvider.linkedin => FontAwesomeIcons.linkedin,
+    OAuthProvider.linkedinOidc => FontAwesomeIcons.linkedin,
+    OAuthProvider.slack => FontAwesomeIcons.slack,
+    OAuthProvider.slackOidc => FontAwesomeIcons.slack,
+    OAuthProvider.spotify => FontAwesomeIcons.spotify,
+    OAuthProvider.twitch => FontAwesomeIcons.twitch,
+    OAuthProvider.twitter => FontAwesomeIcons.xTwitter,
+    _ => FontAwesomeIcons.xmark,
+  };
 
   Color get btnBgColor => switch (this) {
-        OAuthProvider.apple => Colors.black,
-        OAuthProvider.azure => Colors.blueAccent,
-        OAuthProvider.bitbucket => Colors.blue,
-        OAuthProvider.discord => Colors.purple,
-        OAuthProvider.facebook => const Color(0xFF3b5998),
-        OAuthProvider.figma => const Color.fromRGBO(241, 77, 27, 1),
-        OAuthProvider.github => Colors.black,
-        OAuthProvider.gitlab => Colors.deepOrange,
-        OAuthProvider.google => Colors.white,
-        OAuthProvider.kakao => const Color(0xFFFFE812),
-        OAuthProvider.keycloak => const Color.fromRGBO(0, 138, 170, 1),
-        OAuthProvider.linkedin => const Color.fromRGBO(0, 136, 209, 1),
-        OAuthProvider.linkedinOidc => const Color.fromRGBO(0, 136, 209, 1),
-        OAuthProvider.notion => const Color.fromRGBO(69, 75, 78, 1),
-        OAuthProvider.slack => const Color.fromRGBO(74, 21, 75, 1),
-        OAuthProvider.slackOidc => const Color.fromRGBO(74, 21, 75, 1),
-        OAuthProvider.spotify => Colors.green,
-        OAuthProvider.twitch => Colors.purpleAccent,
-        OAuthProvider.twitter => Colors.black,
-        OAuthProvider.workos => const Color.fromRGBO(99, 99, 241, 1),
-        // ignore: unreachable_switch_case
-        _ => Colors.black,
-      };
+    OAuthProvider.apple => Colors.black,
+    OAuthProvider.azure => Colors.blueAccent,
+    OAuthProvider.bitbucket => Colors.blue,
+    OAuthProvider.discord => Colors.purple,
+    OAuthProvider.facebook => const Color(0xFF3b5998),
+    OAuthProvider.figma => const Color.fromRGBO(241, 77, 27, 1),
+    OAuthProvider.github => Colors.black,
+    OAuthProvider.gitlab => Colors.deepOrange,
+    OAuthProvider.google => Colors.white,
+    OAuthProvider.kakao => const Color(0xFFFFE812),
+    OAuthProvider.keycloak => const Color.fromRGBO(0, 138, 170, 1),
+    OAuthProvider.linkedin => const Color.fromRGBO(0, 136, 209, 1),
+    OAuthProvider.linkedinOidc => const Color.fromRGBO(0, 136, 209, 1),
+    OAuthProvider.notion => const Color.fromRGBO(69, 75, 78, 1),
+    OAuthProvider.slack => const Color.fromRGBO(74, 21, 75, 1),
+    OAuthProvider.slackOidc => const Color.fromRGBO(74, 21, 75, 1),
+    OAuthProvider.spotify => Colors.green,
+    OAuthProvider.twitch => Colors.purpleAccent,
+    OAuthProvider.twitter => Colors.black,
+    OAuthProvider.workos => const Color.fromRGBO(99, 99, 241, 1),
+    // ignore: unreachable_switch_case
+    _ => Colors.black,
+  };
 
   String get labelText {
     final modifiedName = name.replaceAll('Oidc', '');
@@ -182,7 +182,8 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
 
     if (idToken == null) {
       throw const AuthException(
-          'No ID Token found from Google sign in result.');
+        'No ID Token found from Google sign in result.',
+      );
     }
 
     return supabase.auth.signInWithIdToken(
@@ -207,7 +208,8 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
     final idToken = credential.identityToken;
     if (idToken == null) {
       throw const AuthException(
-          'Could not find ID Token from generated Apple sign in credential.');
+        'Could not find ID Token from generated Apple sign in credential.',
+      );
     }
 
     return supabase.auth.signInWithIdToken(
@@ -221,16 +223,16 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
   void initState() {
     super.initState();
     localization = widget.localization;
-    _gotrueSubscription =
-        Supabase.instance.client.auth.onAuthStateChange.listen((data) {
-      final session = data.session;
-      if (session != null && mounted && session.user.isAnonymous != true) {
-        widget.onSuccess.call(session);
-        if (widget.showSnackBars && widget.showSuccessSnackBar) {
-          context.showSnackBar(localization.successSignInMessage);
-        }
-      }
-    });
+    _gotrueSubscription = Supabase.instance.client.auth.onAuthStateChange
+        .listen((data) {
+          final session = data.session;
+          if (session != null && mounted && session.user.isAnonymous != true) {
+            widget.onSuccess.call(session);
+            if (widget.showSnackBars && widget.showSuccessSnackBar) {
+              context.showSnackBar(localization.successSignInMessage);
+            }
+          }
+        });
   }
 
   @override
@@ -329,7 +331,7 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
               final iosClientId = googleAuthConfig?.iosClientId;
               final shouldPerformNativeGoogleSignIn =
                   (webClientId != null && !kIsWeb && Platform.isAndroid) ||
-                      (iosClientId != null && !kIsWeb && Platform.isIOS);
+                  (iosClientId != null && !kIsWeb && Platform.isIOS);
               if (shouldPerformNativeGoogleSignIn) {
                 await _nativeGoogleSignIn(
                   webClientId: webClientId,
@@ -343,7 +345,7 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
             if (socialProvider == OAuthProvider.apple) {
               final shouldPerformNativeAppleSignIn =
                   (isNativeAppleAuthEnabled && !kIsWeb && Platform.isIOS) ||
-                      (isNativeAppleAuthEnabled && !kIsWeb && Platform.isMacOS);
+                  (isNativeAppleAuthEnabled && !kIsWeb && Platform.isMacOS);
               if (shouldPerformNativeAppleSignIn) {
                 await _nativeAppleSignIn();
                 return;
@@ -380,8 +382,9 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
             if (widget.onError == null &&
                 widget.showSnackBars &&
                 context.mounted) {
-              context
-                  .showErrorSnackBar('${localization.unexpectedError}: $error');
+              context.showErrorSnackBar(
+                '${localization.unexpectedError}: $error',
+              );
             } else {
               widget.onError?.call(error);
             }

--- a/lib/src/components/supa_verify_phone.dart
+++ b/lib/src/components/supa_verify_phone.dart
@@ -98,7 +98,8 @@ class _SupaVerifyPhoneState extends State<SupaVerifyPhone> {
                     widget.showSnackBars &&
                     context.mounted) {
                   context.showErrorSnackBar(
-                      '${localization.unexpectedErrorOccurred}: $error');
+                    '${localization.unexpectedErrorOccurred}: $error',
+                  );
                 } else {
                   widget.onError?.call(error);
                 }

--- a/lib/src/utils/constants.dart
+++ b/lib/src/utils/constants.dart
@@ -18,17 +18,19 @@ extension ShowSnackBar on BuildContext {
     Color? backgroundColor,
     String? actionLabel,
   }) {
-    ScaffoldMessenger.of(this).showSnackBar(SnackBar(
-      content: Text(
-        message,
-        style: textColor == null ? null : TextStyle(color: textColor),
+    ScaffoldMessenger.of(this).showSnackBar(
+      SnackBar(
+        content: Text(
+          message,
+          style: textColor == null ? null : TextStyle(color: textColor),
+        ),
+        backgroundColor: backgroundColor,
+        action: SnackBarAction(
+          label: actionLabel ?? 'ok',
+          onPressed: () {},
+        ),
       ),
-      backgroundColor: backgroundColor,
-      action: SnackBarAction(
-        label: actionLabel ?? 'ok',
-        onPressed: () {},
-      ),
-    ));
+    );
   }
 
   /// Displays a red snackbar indicating error

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,23 +5,23 @@ homepage: https://supabase.com
 repository: 'https://github.com/supabase-community/supabase_auth_ui'
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
-  flutter: '>=3.0.0'
+  sdk: '>=3.9.0 <4.0.0'
+  flutter: '>=3.35.0'
 
 dependencies:
   flutter:
     sdk: flutter
-  supabase_flutter: ^2.5.6
-  email_validator: ^2.0.1
+  supabase_flutter: ^2.15.0
+  email_validator: ^3.0.0
   font_awesome_flutter: ^11.0.0
   google_sign_in: ^7.2.0
-  sign_in_with_apple: ^6.1.0
-  crypto: ^3.0.3
+  sign_in_with_apple: ^7.0.1
+  crypto: ^3.0.7
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^4.0.0
+  supabase_lints: ^0.1.0
 
 flutter:
   assets:


### PR DESCRIPTION
## What

Raise the minimum Dart SDK to `>=3.9.0 <4.0.0` and Flutter to `>=3.35.0` (the release that bundles Dart 3.9.0), then bump dependency lower bounds to versions that make sense with that floor.

### Dependencies
| Package | Before | After | Note |
|---|---|---|---|
| supabase_flutter | ^2.5.6 | ^2.15.0 | latest |
| email_validator | ^2.0.1 | ^3.0.0 | latest |
| font_awesome_flutter | ^11.0.0 | ^11.0.0 | already bumped in #152 |
| google_sign_in | ^7.2.0 | ^7.2.0 | already latest |
| sign_in_with_apple | ^6.1.0 | ^7.0.1 | 8.x requires Dart 3.11 |
| crypto | ^3.0.3 | ^3.0.7 | latest |

### Linting
Replaced `flutter_lints` with `supabase_lints` in both the package and the example, pointing `analysis_options.yaml` at `package:supabase_lints/analysis_options_flutter.yaml`.

### Other
- Bumped the example's SDK floor to match and regenerated its plugin registrants for the new transitive dependencies.
- Raising the language version to 3.9 switches `dart format` to the new tall style, so `lib` is reformatted in a separate commit to keep CI's format check green.

## Testing
- `flutter analyze --fatal-warnings --fatal-infos lib` clean
- `dart format lib test -l 80 --set-exit-if-changed` clean
- `flutter test` passing

This is the first of two PRs; a follow-up sets up Melos 8.0.0.