### PR TITLE
chore: set up Melos 8.0.0 for the single package

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -9,11 +9,12 @@ environment:
   sdk: '>=3.9.0 <4.0.0'
   flutter: '>=3.35.0'
 
+resolution: workspace
+
 dependencies:
   flutter:
     sdk: flutter
-  supabase_auth_ui:
-    path: ../
+  supabase_auth_ui: any
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,9 @@ environment:
   sdk: '>=3.9.0 <4.0.0'
   flutter: '>=3.35.0'
 
+workspace:
+  - example
+
 dependencies:
   flutter:
     sdk: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,11 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  melos: ^8.0.0
   supabase_lints: ^0.1.0
+
+melos:
+  useRootAsPackage: true
 
 flutter:
   assets:


### PR DESCRIPTION
## What

Sets up [Melos](https://melos.invertase.dev) 8.0.0 for this repository following the [single-package (non-monorepo) guide](https://melos.invertase.dev/getting-started#single-package-projects-non-monorepo).

- Adds `melos: ^8.0.0` as a dev dependency.
- Configures single-package mode with `useRootAsPackage: true` under a top-level `melos:` section in `pubspec.yaml`.
- Declares a **pub workspace** with the example as a member and drops the example's `path` dependency on `supabase_auth_ui`; the example now resolves the package through the shared workspace resolution (single root `pubspec.lock`).

## Testing
- `melos list` → `example`, `supabase_auth_ui`
- `melos bootstrap` → 2 packages bootstrapped
- `flutter analyze --fatal-infos lib`, format, and `flutter test` all pass

## Note
Melos 8.0.0 requires Dart `^3.9.0`, so this is **stacked on #157** (the SDK bump). Once #157 merges, GitHub will retarget this PR to `main`.