### PR TITLE
docs: use plain img for logo so it renders on pub.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
 <br />
 <p align="center">
   <a href="https://supabase.com">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/supabase/supabase/master/packages/common/assets/images/supabase-logo-wordmark--dark.svg">
-      <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/supabase/supabase/master/packages/common/assets/images/supabase-logo-wordmark--light.svg">
-      <img alt="Supabase Logo" width="300" src="https://raw.githubusercontent.com/supabase/supabase/master/packages/common/assets/images/logo-preview.jpg">
-    </picture>
+    <img alt="Supabase Logo" width="300" src="https://raw.githubusercontent.com/supabase/supabase/master/packages/common/assets/images/logo-preview.jpg">
   </a>
 
   <h1 align="center">supabase_auth_ui</h1>


### PR DESCRIPTION
## What

Replaces the `<picture>`/`<source>` + SVG logo block at the top of the README with a single plain `<img>` pointing at `logo-preview.jpg`.

## Why

The logo did not render on the package's pub.dev page. pub.dev does not render SVGs or `<picture>`/`<source>` elements in READMEs, so the entire logo block was dropped.

This follows the same pattern Flame uses: a single plain `<img>` pointing at a raster image. `logo-preview.jpg` carries its own dark background, so it reads well on both the light and dark pub.dev themes.

Same fix as supabase/supabase-flutter#1458.