### PR TITLE
fix: pre-checked required BooleanMetaDataField passes validation

### DIFF
--- a/lib/src/components/supa_email_auth.dart
+++ b/lib/src/components/supa_email_auth.dart
@@ -434,6 +434,7 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                         // hasn't checked it when submitting the form.
                         if (metadataField is BooleanMetaDataField)
                           FormField<bool>(
+                            initialValue: metadataField.value,
                             validator: metadataField.isRequired
                                 ? (bool? value) {
                                     if (value != true) {


### PR DESCRIPTION
## Problem

When a `BooleanMetaDataField` is configured with both `value: true` (initially checked) and `isRequired: true`, submitting the form without touching the checkbox shows the "This field is required" error, even though the checkbox is rendered as checked. The user has to uncheck and re-check the box to submit successfully.

Fixes #145

## Cause

The `FormField<bool>` that wraps the checkbox was created without an `initialValue`. The checkbox itself reads its displayed state from `_metadataControllers` (which does start at `value`), but the `FormField`'s internal value starts as `null`. The validator runs against the `FormField` value, so it sees `null` (not `true`) on the first submit. Toggling the checkbox calls `field.didChange`, which finally syncs the `FormField` value, which is why uncheck/recheck works around it.

## Fix

Pass `metadataField.value` as the `FormField`'s `initialValue` so the validator sees the correct value on the first submit.

```dart
FormField<bool>(
  initialValue: metadataField.value,
  validator: ...,
)
```