### PR TITLE
fix: persist full name on native Apple sign in

### DIFF
--- a/lib/src/components/supa_socials_auth.dart
+++ b/lib/src/components/supa_socials_auth.dart
@@ -212,11 +212,34 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
       );
     }
 
-    return supabase.auth.signInWithIdToken(
+    final response = await supabase.auth.signInWithIdToken(
       provider: OAuthProvider.apple,
       idToken: idToken,
       nonce: rawNonce,
     );
+
+    // Apple only returns the user's name on the credential the first time the
+    // user signs in, and it is never part of the ID token, so persist it to the
+    // user's metadata here.
+    final givenName = credential.givenName;
+    final familyName = credential.familyName;
+    if (givenName != null || familyName != null) {
+      final fullName = [
+        givenName,
+        familyName,
+      ].where((name) => name != null && name.isNotEmpty).join(' ');
+      await supabase.auth.updateUser(
+        UserAttributes(
+          data: {
+            if (givenName != null) 'first_name': givenName,
+            if (familyName != null) 'last_name': familyName,
+            if (fullName.isNotEmpty) 'full_name': fullName,
+          },
+        ),
+      );
+    }
+
+    return response;
   }
 
   @override


### PR DESCRIPTION
## Problem

When signing in with native Apple auth (`enableNativeAppleAuth: true`), the user's full name is never saved to Supabase, even though the `fullName` scope is requested. The same flow works for Google.

Fixes #133

## Cause

Apple returns the user's name only on the `AuthorizationCredentialAppleID` credential (`givenName` / `familyName`), and it is **never** part of the ID token, and it is only returned on the *first* sign in. Because `_nativeAppleSignIn` only called `signInWithIdToken`, the name on the credential was discarded and never reached the backend. Google, by contrast, includes the name in its ID token, which is why it works there.

## Fix

After `signInWithIdToken` succeeds, if the credential carried a given and/or family name, persist it to the user's metadata via `updateUser`:

```dart
final givenName = credential.givenName;
final familyName = credential.familyName;
if (givenName != null || familyName != null) {
  final fullName = [givenName, familyName]
      .where((name) => name != null && name.isNotEmpty)
      .join(' ');
  await supabase.auth.updateUser(
    UserAttributes(
      data: {
        if (givenName != null) 'first_name': givenName,
        if (familyName != null) 'last_name': familyName,
        if (fullName.isNotEmpty) 'full_name': fullName,
      },
    ),
  );
}
```

This matches the approach proposed in #133 and the earlier discussion in #105.