### PR TITLE
fix: only fire onSuccess on SupaSocialsAuth for a fresh sign in

### DIFF
--- a/lib/src/components/supa_socials_auth.dart
+++ b/lib/src/components/supa_socials_auth.dart
@@ -226,7 +226,14 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
     _gotrueSubscription = Supabase.instance.client.auth.onAuthStateChange
         .listen((data) {
           final session = data.session;
-          if (session != null && mounted && session.user.isAnonymous != true) {
+          // Only react to a fresh sign in. The stream replays the initial
+          // session when the widget mounts and also emits events such as
+          // token refreshes and user updates, none of which should trigger
+          // onSuccess again.
+          if (data.event == AuthChangeEvent.signedIn &&
+              session != null &&
+              mounted &&
+              session.user.isAnonymous != true) {
             widget.onSuccess.call(session);
             if (widget.showSnackBars && widget.showSuccessSnackBar) {
               context.showSnackBar(localization.successSignInMessage);


### PR DESCRIPTION
## Problem

`SupaSocialsAuth`'s `onSuccess` callback fires twice: once immediately when the widget mounts (for an already authenticated user) and again on the actual sign in. This breaks flows that redirect or trigger side effects from `onSuccess`.

Fixes #128

## Cause

The `onAuthStateChange` listener called `onSuccess` for **any** event that carried a non-null, non-anonymous session:

```dart
if (session != null && mounted && session.user.isAnonymous != true) {
  widget.onSuccess.call(session);
}
```

The auth stream is backed by a `BehaviorSubject` that replays the last state (`AuthChangeEvent.initialSession`) to new listeners. So when the widget mounts with a pre-existing session, `onSuccess` fires on load, then fires again on `AuthChangeEvent.signedIn` after the user actually signs in. Other events (token refresh, user update) would also have triggered it.

## Fix

Gate the callback on `AuthChangeEvent.signedIn` so only a genuine sign in triggers it:

```dart
if (data.event == AuthChangeEvent.signedIn &&
    session != null &&
    mounted &&
    session.user.isAnonymous != true) {
  widget.onSuccess.call(session);
  ...
}
```

This also avoids re-firing `onSuccess` on the `userUpdated` event, which is relevant alongside #163 (which calls `updateUser` after native Apple sign in).