### PR TITLE
docs: fix invalid snippet and misleading redirect URLs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,6 @@ SupaEmailAuth(
               // do something, for example: navigate("terms_and_conditions");
             },
         ),
-        // Or use some other custom widget.
-        WidgetSpan()
       ],
     ),
   ]),
@@ -118,7 +116,7 @@ Use `SupaMagicAuth` widget to create a magic link signIn form. You need to setup
 
 ```dart
 SupaMagicAuth(
-  redirectUrl: kIsWeb ? null : 'io.supabase.flutter://reset-callback/',
+  redirectUrl: kIsWeb ? null : 'io.supabase.flutter://login-callback/',
   onSuccess: (Session response) {
     // do something, for example: navigate('home');
   },
@@ -157,7 +155,7 @@ SupaSocialsAuth(
     colored: true,
     redirectUrl: kIsWeb
           ? null
-          : 'io.supabase.flutter://reset-callback/',
+          : 'io.supabase.flutter://login-callback/',
     onSuccess: (Session response) {
         // do something, for example: navigate('home');
     },
@@ -205,7 +203,7 @@ SupaPhoneAuth(
 
 // Magic Link Auth
 SupaMagicAuth(
-  redirectUrl: kIsWeb ? null : 'io.supabase.flutter://reset-callback/',
+  redirectUrl: kIsWeb ? null : 'io.supabase.flutter://login-callback/',
   enableAutomaticFormSubmission: false,
   onSuccess: (Session response) {
     // handle success


### PR DESCRIPTION
Two small README correctness fixes found while auditing the docs:

- Remove the bare `WidgetSpan()` from the `metadataFields` example in the Email Auth section. As written it does not compile (`WidgetSpan` requires a `child`); it was a leftover placeholder.
- Rename the example deep link from `io.supabase.flutter://reset-callback/` to `…/login-callback/` in the Magic Link and Social Auth examples. Those are sign-in flows, so `reset-callback` (a copy-paste leftover from password reset) was misleading.