### PR TITLE
ci: drop GitHub App token from release workflows

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -23,18 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - name: Generate token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.PRIVATE_KEY }}
-
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Flutter
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
@@ -49,4 +41,3 @@ jobs:
           run-versioning-graduate: ${{ inputs.graduate == true }}
           create-pr: true
           pr-title: 'chore(release): publish packages'
-          token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -16,13 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - name: Generate token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.PRIVATE_KEY }}
-
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -38,4 +31,3 @@ jobs:
         with:
           publish: true
           create-release: true
-          token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -19,21 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - name: Generate token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.PRIVATE_KEY }}
-          permission-contents: write
-          permission-pull-requests: write
-          permission-actions: write
-
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Flutter
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
@@ -44,7 +33,6 @@ jobs:
         uses: bluefireteam/melos-action@2982f8e4fc92440a219490009d6d05195cb1a6a5 # v3.8.0
         with:
           tag: true
-          token: ${{ steps.app-token.outputs.token }}
 
       - name: Trigger publish workflows
         run: |
@@ -52,4 +40,4 @@ jobs:
           gh workflow run release-publish.yml \
           --ref \$MELOS_PACKAGE_NAME-v\$MELOS_PACKAGE_VERSION
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

The release pipeline (`release-prepare`, `release-publish`, `release-tag`) was failing at the *Generate token* step:

> Error: The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string.

([failing run](https://github.com/supabase-community/supabase_auth_ui/actions/runs/28086056657/job/83152203760))

## Why

The workflows added in #159 relied on a GitHub App (`secrets.APP_ID` / `secrets.PRIVATE_KEY`) that was never configured in this repo, so `create-github-app-token` aborted with an empty input.

## Change

The GitHub App is not needed. Following the [flame-engine/flame](https://github.com/flame-engine/flame/tree/main/.github/workflows) release setup, the whole pipeline runs on the built-in `GITHUB_TOKEN`:

- `release-prepare` and `release-publish` use the default `GITHUB_TOKEN`
- pub.dev publishing uses OIDC (`id-token: write`) — no credentials needed
- `release-tag` pushes tags and triggers `release-publish` via `gh workflow run` with `GITHUB_TOKEN`

No secrets or variables need to be configured.

## Trade-off

The auto-generated release PR is created with `GITHUB_TOKEN`, so it will not trigger CI (`test`, `title-validation`) on the PR itself. This matches flame's behavior; the PR is a version-bump only.

## Note

pub.dev automated publishing (OIDC) must be enabled for each package on pub.dev (Admin → Automated publishing → GitHub Actions) for `release-publish` to succeed.