### PR TITLE
refactor: deduplicate auth error handling and password validation

### DIFF
--- a/lib/src/components/supa_email_auth.dart
+++ b/lib/src/components/supa_email_auth.dart
@@ -397,12 +397,7 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                     : TextInputAction.done,
                 validator:
                     widget.passwordValidator ??
-                    (value) {
-                      if (value == null || value.isEmpty || value.length < 6) {
-                        return localization.passwordLengthError;
-                      }
-                      return null;
-                    },
+                    defaultPasswordValidator(localization.passwordLengthError),
                 onFieldSubmitted: (_) {
                   if ((widget.metadataFields == null || _isSigningIn) &&
                       widget.enableAutomaticFormSubmission) {
@@ -601,14 +596,9 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
                   textInputAction: TextInputAction.next,
                   validator:
                       widget.passwordValidator ??
-                      (value) {
-                        if (value == null ||
-                            value.isEmpty ||
-                            value.length < 6) {
-                          return localization.passwordLengthError;
-                        }
-                        return null;
-                      },
+                      defaultPasswordValidator(
+                        localization.passwordLengthError,
+                      ),
                 ),
                 spacer(16),
                 TextFormField(
@@ -694,20 +684,15 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
         }
         widget.onSignUpComplete.call(response);
       }
-    } on AuthException catch (error) {
-      if (widget.onError == null && widget.showSnackBars && mounted) {
-        context.showErrorSnackBar(error.message);
-      } else {
-        widget.onError?.call(error);
-      }
-      _emailFocusNode.requestFocus();
     } catch (error) {
-      if (widget.onError == null && widget.showSnackBars && mounted) {
-        context.showErrorSnackBar(
-          '${widget.localization.unexpectedError}: $error',
+      if (mounted) {
+        handleAuthError(
+          context,
+          error,
+          onError: widget.onError,
+          showSnackBars: widget.showSnackBars,
+          unexpectedErrorText: widget.localization.unexpectedError,
         );
-      } else {
-        widget.onError?.call(error);
       }
       _emailFocusNode.requestFocus();
     }
@@ -750,8 +735,6 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
       if (!widget.useOtpForPasswordRecovery) {
         widget.onToggleRecoverPassword?.call(_isRecoveringPassword);
       }
-    } on AuthException catch (error) {
-      widget.onError?.call(error);
     } catch (error) {
       widget.onError?.call(error);
     } finally {
@@ -805,8 +788,6 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
         _isEnteringOtp = false;
       });
       widget.onToggleRecoverPassword?.call(_isRecoveringPassword);
-    } on AuthException catch (error) {
-      widget.onError?.call(error);
     } catch (error) {
       widget.onError?.call(error);
     } finally {
@@ -823,9 +804,10 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
   /// In case both MetadataFields and extraMetadata have the same
   /// key in their map, the MetadataFields (form fields) win
   Map<String, dynamic> _resolveData() {
-    var extra = widget.extraMetadata ?? <String, dynamic>{};
-    extra.addAll(_resolveMetadataFieldsData());
-    return extra;
+    return {
+      ...?widget.extraMetadata,
+      ..._resolveMetadataFieldsData(),
+    };
   }
 
   /// Resolve the user_metadata coming from the metadataFields

--- a/lib/src/components/supa_magic_auth.dart
+++ b/lib/src/components/supa_magic_auth.dart
@@ -90,17 +90,15 @@ class _SupaMagicAuthState extends State<SupaMagicAuth> {
       if (widget.showSnackBars && mounted) {
         context.showSnackBar(localization.checkYourEmail);
       }
-    } on AuthException catch (error) {
-      if (widget.onError == null && widget.showSnackBars && mounted) {
-        context.showErrorSnackBar(error.message);
-      } else {
-        widget.onError?.call(error);
-      }
     } catch (error) {
-      if (widget.onError == null && widget.showSnackBars && mounted) {
-        context.showErrorSnackBar('${localization.unexpectedError}: $error');
-      } else {
-        widget.onError?.call(error);
+      if (mounted) {
+        handleAuthError(
+          context,
+          error,
+          onError: widget.onError,
+          showSnackBars: widget.showSnackBars,
+          unexpectedErrorText: localization.unexpectedError,
+        );
       }
     }
     if (mounted) {

--- a/lib/src/components/supa_phone_auth.dart
+++ b/lib/src/components/supa_phone_auth.dart
@@ -49,11 +49,6 @@ class _SupaPhoneAuthState extends State<SupaPhoneAuth> {
   final _password = TextEditingController();
 
   @override
-  void initState() {
-    super.initState();
-  }
-
-  @override
   void dispose() {
     _phone.dispose();
     _password.dispose();
@@ -67,14 +62,13 @@ class _SupaPhoneAuthState extends State<SupaPhoneAuth> {
       return;
     }
     try {
+      final AuthResponse response;
       if (isSigningIn) {
-        final response = await supabase.auth.signInWithPassword(
+        response = await supabase.auth.signInWithPassword(
           phone: _phone.text,
           password: _password.text,
         );
-        widget.onSuccess(response);
       } else {
-        late final AuthResponse response;
         final user = supabase.auth.currentUser;
         if (user?.isAnonymous == true) {
           await supabase.auth.updateUser(
@@ -83,27 +77,25 @@ class _SupaPhoneAuthState extends State<SupaPhoneAuth> {
               password: _password.text,
             ),
           );
+          response = AuthResponse(session: supabase.auth.currentSession);
         } else {
           response = await supabase.auth.signUp(
             phone: _phone.text,
             password: _password.text,
           );
         }
-        if (!mounted) return;
-        widget.onSuccess(response);
       }
-    } on AuthException catch (error) {
-      if (widget.onError == null && widget.showSnackBars && mounted) {
-        context.showErrorSnackBar(error.message);
-      } else {
-        widget.onError?.call(error);
-      }
+      if (!mounted) return;
+      widget.onSuccess(response);
     } catch (error) {
-      if (widget.onError == null && widget.showSnackBars && mounted) {
-        context.showErrorSnackBar('${localization.unexpectedError}: $error');
-      } else {
-        widget.onError?.call(error);
-      }
+      if (!mounted) return;
+      handleAuthError(
+        context,
+        error,
+        onError: widget.onError,
+        showSnackBars: widget.showSnackBars,
+        unexpectedErrorText: localization.unexpectedError,
+      );
     }
   }
 
@@ -141,12 +133,9 @@ class _SupaPhoneAuthState extends State<SupaPhoneAuth> {
                   ? [AutofillHints.password]
                   : [AutofillHints.newPassword],
               textInputAction: TextInputAction.done,
-              validator: (value) {
-                if (value == null || value.isEmpty || value.length < 6) {
-                  return localization.passwordLengthError;
-                }
-                return null;
-              },
+              validator: defaultPasswordValidator(
+                localization.passwordLengthError,
+              ),
               onFieldSubmitted: (_) async {
                 if (widget.enableAutomaticFormSubmission) {
                   await _submitForm();

--- a/lib/src/components/supa_reset_password.dart
+++ b/lib/src/components/supa_reset_password.dart
@@ -69,20 +69,15 @@ class _SupaResetPasswordState extends State<SupaResetPassword> {
       if (widget.showSnackBars) {
         context.showSnackBar(localization.passwordResetSent);
       }
-    } on AuthException catch (error) {
-      if (widget.onError == null && widget.showSnackBars && mounted) {
-        context.showErrorSnackBar(error.message);
-      } else {
-        widget.onError?.call(error);
-      }
     } catch (error) {
-      if (widget.onError == null && widget.showSnackBars && mounted) {
-        context.showErrorSnackBar(
-          '${localization.passwordLengthError}: $error',
-        );
-      } else {
-        widget.onError?.call(error);
-      }
+      if (!mounted) return;
+      handleAuthError(
+        context,
+        error,
+        onError: widget.onError,
+        showSnackBars: widget.showSnackBars,
+        unexpectedErrorText: localization.passwordLengthError,
+      );
     }
   }
 
@@ -99,12 +94,9 @@ class _SupaResetPasswordState extends State<SupaResetPassword> {
             labelText: localization.enterPassword,
             prefixIcon: const Icon(Icons.lock),
             autofillHints: const [AutofillHints.newPassword],
-            validator: (value) {
-              if (value == null || value.isEmpty || value.length < 6) {
-                return localization.passwordLengthError;
-              }
-              return null;
-            },
+            validator: defaultPasswordValidator(
+              localization.passwordLengthError,
+            ),
             onFieldSubmitted: (_) async {
               if (widget.enableAutomaticFormSubmission) {
                 await _updatePassword();

--- a/lib/src/components/supa_socials_auth.dart
+++ b/lib/src/components/supa_socials_auth.dart
@@ -61,6 +61,17 @@ extension on OAuthProvider {
     final modifiedName = name.replaceAll('Oidc', '');
     return 'Continue with ${modifiedName[0].toUpperCase()}${modifiedName.substring(1)}';
   }
+
+  /// Asset path for providers that ship a custom logo image instead of using
+  /// a Font Awesome icon. Returns `null` when the Font Awesome icon should be
+  /// used.
+  String? get logoAsset => switch (this) {
+    OAuthProvider.notion => 'assets/logos/notion.png',
+    OAuthProvider.kakao => 'assets/logos/kakao.png',
+    OAuthProvider.keycloak => 'assets/logos/keycloak.png',
+    OAuthProvider.workos => 'assets/logos/workOS.png',
+    _ => null,
+  };
 }
 
 enum SocialButtonVariant {
@@ -266,8 +277,8 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
 
   @override
   void dispose() {
-    super.dispose();
     _gotrueSubscription.cancel();
+    super.dispose();
   }
 
   @override
@@ -275,7 +286,7 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
     final providers = widget.socialProviders;
     final googleAuthConfig = widget.nativeGoogleAuthConfig;
     final isNativeAppleAuthEnabled = widget.enableNativeAppleAuth;
-    final coloredBg = widget.colored == true;
+    final coloredBg = widget.colored;
 
     if (providers.isEmpty) {
       return ErrorWidget(Exception('Social provider list cannot be empty'));
@@ -302,6 +313,18 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
             ),
           ),
         );
+        final logoAsset = socialProvider.logoAsset;
+        if (logoAsset != null) {
+          iconWidget = Image.asset(
+            logoAsset,
+            package: 'supabase_auth_ui',
+            color: socialProvider == OAuthProvider.workos && coloredBg
+                ? Colors.white
+                : null,
+            width: 48,
+            height: 48,
+          );
+        }
         if (socialProvider == OAuthProvider.google && coloredBg) {
           iconWidget = Image.asset(
             'assets/logos/google_light.png',
@@ -312,44 +335,6 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
           foregroundColor = Colors.black;
           backgroundColor = Colors.white;
           overlayColor = Colors.white;
-        }
-
-        switch (socialProvider) {
-          case OAuthProvider.notion:
-            iconWidget = Image.asset(
-              'assets/logos/notion.png',
-              package: 'supabase_auth_ui',
-              width: 48,
-              height: 48,
-            );
-            break;
-          case OAuthProvider.kakao:
-            iconWidget = Image.asset(
-              'assets/logos/kakao.png',
-              package: 'supabase_auth_ui',
-              width: 48,
-              height: 48,
-            );
-            break;
-          case OAuthProvider.keycloak:
-            iconWidget = Image.asset(
-              'assets/logos/keycloak.png',
-              package: 'supabase_auth_ui',
-              width: 48,
-              height: 48,
-            );
-            break;
-          case OAuthProvider.workos:
-            iconWidget = Image.asset(
-              'assets/logos/workOS.png',
-              package: 'supabase_auth_ui',
-              color: coloredBg ? Colors.white : null,
-              width: 48,
-              height: 48,
-            );
-            break;
-          default:
-            break;
         }
 
         onAuthButtonPressed() async {
@@ -399,23 +384,15 @@ class _SupaSocialsAuthState extends State<SupaSocialsAuth> {
               queryParams: widget.queryParams?[socialProvider],
               authScreenLaunchMode: widget.authScreenLaunchMode,
             );
-          } on AuthException catch (error) {
-            if (widget.onError == null &&
-                widget.showSnackBars &&
-                context.mounted) {
-              context.showErrorSnackBar(error.message);
-            } else {
-              widget.onError?.call(error);
-            }
           } catch (error) {
-            if (widget.onError == null &&
-                widget.showSnackBars &&
-                context.mounted) {
-              context.showErrorSnackBar(
-                '${localization.unexpectedError}: $error',
+            if (context.mounted) {
+              handleAuthError(
+                context,
+                error,
+                onError: widget.onError,
+                showSnackBars: widget.showSnackBars,
+                unexpectedErrorText: localization.unexpectedError,
               );
-            } else {
-              widget.onError?.call(error);
             }
           }
         }

--- a/lib/src/components/supa_verify_phone.dart
+++ b/lib/src/components/supa_verify_phone.dart
@@ -35,11 +35,6 @@ class _SupaVerifyPhoneState extends State<SupaVerifyPhone> {
   final _code = TextEditingController();
 
   @override
-  void initState() {
-    super.initState();
-  }
-
-  @override
   void dispose() {
     _code.dispose();
     super.dispose();
@@ -85,23 +80,15 @@ class _SupaVerifyPhoneState extends State<SupaVerifyPhone> {
                   type: OtpType.sms,
                 );
                 widget.onSuccess(response);
-              } on AuthException catch (error) {
-                if (widget.onError == null &&
-                    widget.showSnackBars &&
-                    context.mounted) {
-                  context.showErrorSnackBar(error.message);
-                } else {
-                  widget.onError?.call(error);
-                }
               } catch (error) {
-                if (widget.onError == null &&
-                    widget.showSnackBars &&
-                    context.mounted) {
-                  context.showErrorSnackBar(
-                    '${localization.unexpectedErrorOccurred}: $error',
+                if (context.mounted) {
+                  handleAuthError(
+                    context,
+                    error,
+                    onError: widget.onError,
+                    showSnackBars: widget.showSnackBars,
+                    unexpectedErrorText: localization.unexpectedErrorOccurred,
                   );
-                } else {
-                  widget.onError?.call(error);
                 }
               }
               if (mounted) {

--- a/lib/src/utils/constants.dart
+++ b/lib/src/utils/constants.dart
@@ -9,6 +9,40 @@ SizedBox spacer(double height) {
   );
 }
 
+/// Default validator shared by the password fields.
+///
+/// Ensures the password is non-empty and at least 6 characters long.
+String? Function(String?) defaultPasswordValidator(String lengthError) {
+  return (value) {
+    if (value == null || value.isEmpty || value.length < 6) {
+      return lengthError;
+    }
+    return null;
+  };
+}
+
+/// Handles an error thrown by an auth action in the same way across all forms.
+///
+/// Calls [onError] when provided, otherwise shows an error snack bar (when
+/// [showSnackBars] is `true` and the [context] is still mounted). [AuthException]s
+/// show their message, while any other error is prefixed with [unexpectedErrorText].
+void handleAuthError(
+  BuildContext context,
+  Object error, {
+  required void Function(Object error)? onError,
+  required bool showSnackBars,
+  required String unexpectedErrorText,
+}) {
+  if (onError == null && showSnackBars && context.mounted) {
+    final message = error is AuthException
+        ? error.message
+        : '$unexpectedErrorText: $error';
+    context.showErrorSnackBar(message);
+  } else {
+    onError?.call(error);
+  }
+}
+
 /// Set of extension methods to easily display a snackbar
 extension ShowSnackBar on BuildContext {
   /// Displays a basic snackbar


### PR DESCRIPTION
## What

Cleanup and simplification pass across the auth components.

### Shared helpers
- `handleAuthError(...)` — collapses the `on AuthException catch / catch` block that was copy-pasted across all six components into one function.
- `defaultPasswordValidator(lengthError)` — the "at least 6 characters" validator that was duplicated four times.

### Bugs fixed
- **`SupaPhoneAuth`** — on the anonymous-user sign-up path, `response` was declared `late final` but never assigned before `onSuccess(response)`, throwing `LateInitializationError`. It now builds an `AuthResponse` from the current session, mirroring `SupaEmailAuth`.
- **`SupaEmailAuth._resolveData()`** — it did `widget.extraMetadata ?? {}` then `.addAll(...)`, mutating the caller's `extraMetadata` map in place. Now returns a fresh map via spreads.

### Simplifications
- Replaced the duplicated error handling and inline password validators across all six components with the new helpers.
- Merged the two identical catch blocks in `SupaEmailAuth._passwordRecovery` and `_verifyOtpAndResetPassword`.
- `SupaSocialsAuth` — added an `OAuthProvider.logoAsset` getter and folded the four near-identical `Image.asset` blocks (notion/kakao/keycloak/workos) into one; dropped the redundant `colored == true`; cancel the gotrue subscription before `super.dispose()`.
- Removed empty `initState()` overrides in `SupaPhoneAuth` and `SupaVerifyPhone`.

Net: **-164 / +123 lines**, analyzer clean, tests pass.

## Behavior note
Previously `onError` was invoked even if the widget had been unmounted mid-request (it lived in the `else` branch with no `mounted` guard). The new call sites are all wrapped in a `mounted` / `context.mounted` check, so `onError` and the snackbar now only fire while the widget is still mounted. This is consistent across all components and avoids firing callbacks on a disposed widget.