### PR TITLE
fix(example): repair broken routes and surface all example screens

### DIFF
--- a/example/lib/magic_link.dart
+++ b/example/lib/magic_link.dart
@@ -29,7 +29,7 @@ class MagicLink extends StatelessWidget {
                 style: TextStyle(fontWeight: FontWeight.bold),
               ),
               onPressed: () {
-                Navigator.pushNamed(context, '/sign_in');
+                Navigator.pushNamed(context, '/');
               },
             ),
           ],

--- a/example/lib/phone_sign_in.dart
+++ b/example/lib/phone_sign_in.dart
@@ -26,7 +26,7 @@ class PhoneSignIn extends StatelessWidget {
                 style: TextStyle(fontWeight: FontWeight.bold),
               ),
               onPressed: () {
-                Navigator.pushNamed(context, '/');
+                Navigator.pushNamed(context, '/phone_sign_up');
               },
             ),
           ],

--- a/example/lib/phone_sign_up.dart
+++ b/example/lib/phone_sign_up.dart
@@ -26,7 +26,7 @@ class PhoneSignUp extends StatelessWidget {
                 style: TextStyle(fontWeight: FontWeight.bold),
               ),
               onPressed: () {
-                Navigator.of(context).pushNamed('/sign_in');
+                Navigator.of(context).pushNamed('/phone_sign_in');
               },
             ),
           ],

--- a/example/lib/sign_in.dart
+++ b/example/lib/sign_in.dart
@@ -175,6 +175,22 @@ class SignUp extends StatelessWidget {
             label: const Text('Sign in with Phone'),
           ),
           spacer,
+          ElevatedButton.icon(
+            onPressed: () {
+              Navigator.pushNamed(context, '/prefilled');
+            },
+            icon: const Icon(Icons.edit),
+            label: const Text('Sign in with prefilled fields'),
+          ),
+          spacer,
+          ElevatedButton.icon(
+            onPressed: () {
+              Navigator.pushNamed(context, '/update_password');
+            },
+            icon: const Icon(Icons.lock_reset),
+            label: const Text('Update password'),
+          ),
+          spacer,
           SupaSocialsAuth(
             colored: true,
             nativeGoogleAuthConfig: const NativeGoogleAuthConfig(

--- a/example/lib/update_password.dart
+++ b/example/lib/update_password.dart
@@ -16,7 +16,7 @@ class UpdatePassword extends StatelessWidget {
           children: [
             SupaResetPassword(
               accessToken:
-                  Supabase.instance.client.auth.currentSession!.accessToken,
+                  Supabase.instance.client.auth.currentSession?.accessToken,
               onSuccess: (response) {
                 Navigator.of(context).pushReplacementNamed('/home');
               },

--- a/example/lib/verify_phone.dart
+++ b/example/lib/verify_phone.dart
@@ -21,15 +21,6 @@ class VerifyPhone extends StatelessWidget {
             ),
             TextButton(
               child: const Text(
-                'Forgot Password? Click here',
-                style: TextStyle(fontWeight: FontWeight.bold),
-              ),
-              onPressed: () {
-                Navigator.pushNamed(context, '/forgot_password');
-              },
-            ),
-            TextButton(
-              child: const Text(
                 'Take me back to Sign Up',
                 style: TextStyle(fontWeight: FontWeight.bold),
               ),


### PR DESCRIPTION
## What

While going through the example app I found several navigation routes that were either broken or unreachable. This fixes them so every screen in the example is reachable and no button leads to the "Not Found" fallback.

### Broken navigations (target route was never registered → hit the `onUnknownRoute` "Not Found" page)
- `magic_link.dart` navigated to `/sign_in` → now `/` (the email auth screen).
- `phone_sign_up.dart` navigated to `/sign_in` → now `/phone_sign_in`.
- `verify_phone.dart` had a "Forgot Password? Click here" button pointing at `/forgot_password`, which doesn't exist (and is out of place on a phone-verification step). Removed it.

### Unreachable screens (route registered in `main.dart` but nothing navigated to it)
- `phone_sign_in.dart`'s "Don't have an account? Sign Up" pointed at `/` → now `/phone_sign_up`, so the phone sign-up screen is reachable.
- Added entry buttons on the main sign-in screen for `/prefilled` (prefilled fields) and `/update_password` (reset password), which previously had no way to reach them.

### Other
- `update_password.dart` force-unwrapped `currentSession!`, which would crash when opened without a session (now possible via the new button). Changed to `currentSession?.accessToken` to match the README.

After these changes, the set of registered routes and the set of navigation targets match exactly. `flutter analyze` is clean.