### PR TITLE
chore(example): format example and enforce it in lint scripts

### DIFF
--- a/example/lib/constants.dart
+++ b/example/lib/constants.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 
 AppBar appBar(String title) => AppBar(
-      title: Text(title),
-      automaticallyImplyLeading: false,
-    );
+  title: Text(title),
+  automaticallyImplyLeading: false,
+);
 
 const optionText = Text(
   'Or',

--- a/example/lib/magic_link.dart
+++ b/example/lib/magic_link.dart
@@ -29,7 +29,7 @@ class MagicLink extends StatelessWidget {
                 style: TextStyle(fontWeight: FontWeight.bold),
               ),
               onPressed: () {
-                Navigator.pushNamed(context, '/sign_in');
+                Navigator.pushNamed(context, '/');
               },
             ),
           ],

--- a/example/lib/phone_sign_in.dart
+++ b/example/lib/phone_sign_in.dart
@@ -26,7 +26,7 @@ class PhoneSignIn extends StatelessWidget {
                 style: TextStyle(fontWeight: FontWeight.bold),
               ),
               onPressed: () {
-                Navigator.pushNamed(context, '/');
+                Navigator.pushNamed(context, '/phone_sign_up');
               },
             ),
           ],

--- a/example/lib/phone_sign_up.dart
+++ b/example/lib/phone_sign_up.dart
@@ -26,7 +26,7 @@ class PhoneSignUp extends StatelessWidget {
                 style: TextStyle(fontWeight: FontWeight.bold),
               ),
               onPressed: () {
-                Navigator.of(context).pushNamed('/sign_in');
+                Navigator.of(context).pushNamed('/phone_sign_in');
               },
             ),
           ],

--- a/example/lib/sign_in.dart
+++ b/example/lib/sign_in.dart
@@ -28,15 +28,23 @@ class SignUp extends StatelessWidget {
           borderSide: BorderSide.none,
         ),
         labelStyle: const TextStyle(
-            color:
-                Color.fromARGB(179, 255, 255, 255)), // text labeling text entry
+          color: Color.fromARGB(179, 255, 255, 255),
+        ), // text labeling text entry
       ),
       elevatedButtonTheme: ElevatedButtonThemeData(
         style: ElevatedButton.styleFrom(
-          backgroundColor:
-              const Color.fromARGB(255, 22, 135, 188), // main button
-          foregroundColor:
-              const Color.fromARGB(255, 255, 255, 255), // main button text
+          backgroundColor: const Color.fromARGB(
+            255,
+            22,
+            135,
+            188,
+          ), // main button
+          foregroundColor: const Color.fromARGB(
+            255,
+            255,
+            255,
+            255,
+          ), // main button text
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(8),
           ),
@@ -97,64 +105,66 @@ class SignUp extends StatelessWidget {
 
           // Dark theme example
           Card(
-              elevation: 10,
-              color: const Color.fromARGB(255, 24, 24, 24),
-              child: Padding(
-                padding: const EdgeInsets.all(30),
-                child: Theme(
-                  data: darkModeThemeData,
-                  child: SupaEmailAuth(
-                      redirectTo: kIsWeb ? null : 'io.supabase.flutter://',
-                      onSignInComplete: navigateHome,
-                      onSignUpComplete: navigateHome,
-                      prefixIconEmail: null,
-                      prefixIconPassword: null,
-                      localization: const SupaEmailAuthLocalization(
-                          enterEmail: "email",
-                          enterPassword: "password",
-                          dontHaveAccount: "sign up",
-                          forgotPassword: "forgot password"),
-                      metadataFields: [
-                        MetaDataField(
-                          prefixIcon: const Icon(Icons.person),
-                          label: 'Username',
-                          key: 'username',
-                          validator: (val) {
-                            if (val == null || val.isEmpty) {
-                              return 'Please enter something';
-                            }
-                            return null;
-                          },
+            elevation: 10,
+            color: const Color.fromARGB(255, 24, 24, 24),
+            child: Padding(
+              padding: const EdgeInsets.all(30),
+              child: Theme(
+                data: darkModeThemeData,
+                child: SupaEmailAuth(
+                  redirectTo: kIsWeb ? null : 'io.supabase.flutter://',
+                  onSignInComplete: navigateHome,
+                  onSignUpComplete: navigateHome,
+                  prefixIconEmail: null,
+                  prefixIconPassword: null,
+                  localization: const SupaEmailAuthLocalization(
+                    enterEmail: "email",
+                    enterPassword: "password",
+                    dontHaveAccount: "sign up",
+                    forgotPassword: "forgot password",
+                  ),
+                  metadataFields: [
+                    MetaDataField(
+                      prefixIcon: const Icon(Icons.person),
+                      label: 'Username',
+                      key: 'username',
+                      validator: (val) {
+                        if (val == null || val.isEmpty) {
+                          return 'Please enter something';
+                        }
+                        return null;
+                      },
+                    ),
+                    BooleanMetaDataField(
+                      label:
+                          'Keep me up to date with the latest news and updates.',
+                      key: 'marketing_consent',
+                      checkboxPosition: ListTileControlAffinity.leading,
+                    ),
+                    BooleanMetaDataField(
+                      key: 'terms_agreement',
+                      isRequired: true,
+                      checkboxPosition: ListTileControlAffinity.leading,
+                      richLabelSpans: [
+                        const TextSpan(text: 'I have read and agree to the '),
+                        TextSpan(
+                          text: 'Terms and Conditions.',
+                          style: const TextStyle(
+                            color: Colors.blue,
+                          ),
+                          recognizer: TapGestureRecognizer()
+                            ..onTap = () {
+                              //ignore: avoid_print
+                              print('Terms and Conditions');
+                            },
                         ),
-                        BooleanMetaDataField(
-                          label:
-                              'Keep me up to date with the latest news and updates.',
-                          key: 'marketing_consent',
-                          checkboxPosition: ListTileControlAffinity.leading,
-                        ),
-                        BooleanMetaDataField(
-                          key: 'terms_agreement',
-                          isRequired: true,
-                          checkboxPosition: ListTileControlAffinity.leading,
-                          richLabelSpans: [
-                            const TextSpan(
-                                text: 'I have read and agree to the '),
-                            TextSpan(
-                              text: 'Terms and Conditions.',
-                              style: const TextStyle(
-                                color: Colors.blue,
-                              ),
-                              recognizer: TapGestureRecognizer()
-                                ..onTap = () {
-                                  //ignore: avoid_print
-                                  print('Terms and Conditions');
-                                },
-                            ),
-                          ],
-                        ),
-                      ]),
+                      ],
+                    ),
+                  ],
                 ),
-              )),
+              ),
+            ),
+          ),
 
           const Divider(),
           optionText,

--- a/example/lib/sign_in.dart
+++ b/example/lib/sign_in.dart
@@ -175,6 +175,22 @@ class SignUp extends StatelessWidget {
             label: const Text('Sign in with Phone'),
           ),
           spacer,
+          ElevatedButton.icon(
+            onPressed: () {
+              Navigator.pushNamed(context, '/prefilled');
+            },
+            icon: const Icon(Icons.edit),
+            label: const Text('Sign in with prefilled fields'),
+          ),
+          spacer,
+          ElevatedButton.icon(
+            onPressed: () {
+              Navigator.pushNamed(context, '/update_password');
+            },
+            icon: const Icon(Icons.lock_reset),
+            label: const Text('Update password'),
+          ),
+          spacer,
           SupaSocialsAuth(
             colored: true,
             nativeGoogleAuthConfig: const NativeGoogleAuthConfig(

--- a/example/lib/update_password.dart
+++ b/example/lib/update_password.dart
@@ -16,7 +16,7 @@ class UpdatePassword extends StatelessWidget {
           children: [
             SupaResetPassword(
               accessToken:
-                  Supabase.instance.client.auth.currentSession!.accessToken,
+                  Supabase.instance.client.auth.currentSession?.accessToken,
               onSuccess: (response) {
                 Navigator.of(context).pushReplacementNamed('/home');
               },

--- a/example/lib/verify_phone.dart
+++ b/example/lib/verify_phone.dart
@@ -21,15 +21,6 @@ class VerifyPhone extends StatelessWidget {
             ),
             TextButton(
               child: const Text(
-                'Forgot Password? Click here',
-                style: TextStyle(fontWeight: FontWeight.bold),
-              ),
-              onPressed: () {
-                Navigator.pushNamed(context, '/forgot_password');
-              },
-            ),
-            TextButton(
-              child: const Text(
                 'Take me back to Sign Up',
                 style: TextStyle(fontWeight: FontWeight.bold),
               ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,13 +32,13 @@ melos:
 
   scripts:
     analyze:
-      run: flutter analyze --fatal-warnings --fatal-infos lib
+      run: flutter analyze --fatal-warnings --fatal-infos lib example/lib
       description: Run static analysis on the package.
     format:
-      run: dart format lib test -l 80 --set-exit-if-changed
+      run: dart format lib test example/lib -l 80 --set-exit-if-changed
       description: Verify that the code is formatted.
     format:fix:
-      run: dart format lib test -l 80
+      run: dart format lib test example/lib -l 80
       description: Format the code.
     test:
       run: flutter test

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,10 +35,10 @@ melos:
       run: flutter analyze --fatal-warnings --fatal-infos lib example/lib
       description: Run static analysis on the package.
     format:
-      run: dart format lib test example/lib -l 80 --set-exit-if-changed
+      run: dart format lib test example/lib --set-exit-if-changed
       description: Verify that the code is formatted.
     format:fix:
-      run: dart format lib test example/lib -l 80
+      run: dart format lib test example/lib
       description: Format the code.
     test:
       run: flutter test


### PR DESCRIPTION
## What

Formats the example app with `dart format -l 80` (the repo's configured style) and extends the melos lint scripts so the example is actually held to the same standard going forward.

Based on top of #171 so it formats the already-fixed example files.

### Changes
- Ran `dart format example/lib -l 80`, reformatting `example/lib/constants.dart` and `example/lib/sign_in.dart` to match the rest of the codebase.
- Extended the melos `analyze`, `format`, and `format:fix` scripts to include `example/lib`. Previously they only covered the root `lib`/`test`, so the example was never format-checked or analyzed in CI, which is why it had drifted.

The example already had an `analysis_options.yaml` identical to the root's, so no new config file was needed; the missing piece was wiring it into the scripts.

`dart format ... --set-exit-if-changed` and `flutter analyze --fatal-warnings --fatal-infos lib example/lib` both pass.