### PR TITLE
test: add full test suite for auth UI components

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  http: ^1.0.0
   melos: ^8.0.0
   supabase_lints: ^0.1.0
 
@@ -32,7 +33,7 @@ melos:
 
   scripts:
     analyze:
-      run: flutter analyze --fatal-warnings --fatal-infos lib example/lib
+      run: flutter analyze --fatal-warnings --fatal-infos lib test example/lib
       description: Run static analysis on the package.
     format:
       run: dart format lib test example/lib --set-exit-if-changed

--- a/test/components/meta_data_field_test.dart
+++ b/test/components/meta_data_field_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_auth_ui/supabase_auth_ui.dart';
+
+import '../test_utils.dart';
+
+void main() {
+  group('MetaDataField', () {
+    test('stores its label, key, validator and icon', () {
+      validator(String? _) => null;
+      const icon = Icon(Icons.person);
+      final field = MetaDataField(
+        label: 'Username',
+        key: 'username',
+        validator: validator,
+        prefixIcon: icon,
+      );
+
+      expect(field.label, 'Username');
+      expect(field.key, 'username');
+      expect(field.validator, validator);
+      expect(field.prefixIcon, icon);
+    });
+  });
+
+  group('BooleanMetaDataField', () {
+    test('defaults value to false and isRequired to false', () {
+      final field = BooleanMetaDataField(label: 'Consent', key: 'consent');
+
+      expect(field.value, isFalse);
+      expect(field.isRequired, isFalse);
+      expect(field.checkboxPosition, ListTileControlAffinity.platform);
+      expect(field.label, 'Consent');
+    });
+
+    test('asserts that either a label or rich label spans are provided', () {
+      expect(
+        () => BooleanMetaDataField(key: 'consent'),
+        throwsAssertionError,
+      );
+    });
+
+    test('accepts rich label spans without a plain label', () {
+      final field = BooleanMetaDataField(
+        key: 'terms',
+        richLabelSpans: [const TextSpan(text: 'I agree')],
+      );
+
+      expect(field.label, isEmpty);
+      expect(field.richLabelSpans, isNotNull);
+    });
+
+    testWidgets('getLabelWidget renders plain text from the label', (
+      tester,
+    ) async {
+      final field = BooleanMetaDataField(label: 'Consent', key: 'consent');
+
+      await tester.pumpWidget(
+        wrapForTest(Builder(builder: field.getLabelWidget)),
+      );
+
+      expect(find.text('Consent'), findsOneWidget);
+      expect(find.byType(RichText), findsWidgets);
+    });
+
+    testWidgets('getLabelWidget renders the rich label spans', (tester) async {
+      final field = BooleanMetaDataField(
+        key: 'terms',
+        richLabelSpans: [
+          const TextSpan(text: 'I agree to the '),
+          TextSpan(
+            text: 'Terms',
+            recognizer: TapGestureRecognizer()..onTap = () {},
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        wrapForTest(Builder(builder: field.getLabelWidget)),
+      );
+
+      final richText = tester.widget<RichText>(find.byType(RichText).first);
+      expect(richText.text.toPlainText(), 'I agree to the Terms');
+    });
+  });
+}

--- a/test/components/supa_email_auth_test.dart
+++ b/test/components/supa_email_auth_test.dart
@@ -1,0 +1,382 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_auth_ui/supabase_auth_ui.dart';
+
+import '../test_utils.dart';
+
+void main() {
+  setUpAll(initializeSupabaseForTest);
+  setUp(() => testServer.reset());
+
+  Widget buildForm({
+    void Function(AuthResponse response)? onSignInComplete,
+    void Function(AuthResponse response)? onSignUpComplete,
+    void Function(Object error)? onError,
+    void Function(bool isSigningIn)? onToggleSignIn,
+    void Function(bool isRecoveringPassword)? onToggleRecoverPassword,
+    void Function(String email)? onPasswordResetEmailSent,
+    bool isInitiallySigningIn = true,
+    bool showConfirmPasswordField = false,
+    bool useOtpForPasswordRecovery = false,
+    bool showSnackBars = true,
+    List<MetaDataField>? metadataFields,
+    String? prefilledEmail,
+    String? prefilledPassword,
+  }) {
+    return wrapForTest(
+      SupaEmailAuth(
+        onSignInComplete: onSignInComplete ?? (_) {},
+        onSignUpComplete: onSignUpComplete ?? (_) {},
+        onError: onError,
+        onToggleSignIn: onToggleSignIn,
+        onToggleRecoverPassword: onToggleRecoverPassword,
+        onPasswordResetEmailSent: onPasswordResetEmailSent,
+        isInitiallySigningIn: isInitiallySigningIn,
+        showConfirmPasswordField: showConfirmPasswordField,
+        useOtpForPasswordRecovery: useOtpForPasswordRecovery,
+        showSnackBars: showSnackBars,
+        metadataFields: metadataFields,
+        prefilledEmail: prefilledEmail,
+        prefilledPassword: prefilledPassword,
+      ),
+    );
+  }
+
+  group('rendering', () {
+    testWidgets('shows email, password and sign in button by default', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildForm());
+
+      expect(find.text('Enter your email'), findsOneWidget);
+      expect(find.text('Enter your password'), findsOneWidget);
+      expect(find.widgetWithText(ElevatedButton, 'Sign In'), findsOneWidget);
+      expect(find.text('Forgot your password?'), findsOneWidget);
+      expect(find.text("Don't have an account? Sign up"), findsOneWidget);
+    });
+
+    testWidgets('does not show the forgot password button when signing up', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildForm(isInitiallySigningIn: false));
+
+      expect(find.widgetWithText(ElevatedButton, 'Sign Up'), findsOneWidget);
+      expect(find.text('Forgot your password?'), findsNothing);
+      expect(find.text('Already have an account? Sign in'), findsOneWidget);
+    });
+
+    testWidgets('pre-fills the email and password fields', (tester) async {
+      await tester.pumpWidget(
+        buildForm(
+          prefilledEmail: 'prefilled@example.com',
+          prefilledPassword: 'supersecret',
+        ),
+      );
+
+      expect(find.text('prefilled@example.com'), findsOneWidget);
+      expect(find.text('supersecret'), findsOneWidget);
+    });
+  });
+
+  group('validation', () {
+    testWidgets('shows an error for an invalid email', (tester) async {
+      await tester.pumpWidget(buildForm());
+
+      await tester.enterText(find.byType(TextFormField).first, 'not-an-email');
+      await tester.enterText(
+        find.byType(TextFormField).at(1),
+        'longenough',
+      );
+      await tester.tap(find.widgetWithText(ElevatedButton, 'Sign In'));
+      await tester.pump();
+
+      expect(find.text('Please enter a valid email address'), findsOneWidget);
+    });
+
+    testWidgets('shows an error for a too short password', (tester) async {
+      await tester.pumpWidget(buildForm());
+
+      await tester.enterText(
+        find.byType(TextFormField).first,
+        'valid@example.com',
+      );
+      await tester.enterText(find.byType(TextFormField).at(1), '123');
+      await tester.tap(find.widgetWithText(ElevatedButton, 'Sign In'));
+      await tester.pump();
+
+      expect(
+        find.text(
+          'Please enter a password that is at least 6 characters long',
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('does not submit when validation fails', (tester) async {
+      await tester.pumpWidget(buildForm());
+
+      await tester.tap(find.widgetWithText(ElevatedButton, 'Sign In'));
+      await tester.pump();
+
+      expect(testServer.requests, isEmpty);
+    });
+  });
+
+  group('toggling', () {
+    testWidgets('toggles between sign in and sign up', (tester) async {
+      bool? isSigningIn;
+      await tester.pumpWidget(
+        buildForm(onToggleSignIn: (value) => isSigningIn = value),
+      );
+
+      await tester.tap(find.byKey(const ValueKey('toggleSignInButton')));
+      await tester.pumpAndSettle();
+
+      expect(isSigningIn, isFalse);
+      expect(find.widgetWithText(ElevatedButton, 'Sign Up'), findsOneWidget);
+    });
+  });
+
+  group('confirm password field', () {
+    testWidgets('is shown only when signing up', (tester) async {
+      await tester.pumpWidget(
+        buildForm(
+          isInitiallySigningIn: false,
+          showConfirmPasswordField: true,
+        ),
+      );
+
+      expect(find.text('Confirm Password'), findsOneWidget);
+    });
+
+    testWidgets('shows an error when passwords do not match', (tester) async {
+      await tester.pumpWidget(
+        buildForm(
+          isInitiallySigningIn: false,
+          showConfirmPasswordField: true,
+        ),
+      );
+
+      await tester.enterText(
+        find.byType(TextFormField).first,
+        'valid@example.com',
+      );
+      await tester.enterText(find.byType(TextFormField).at(1), 'password1');
+      await tester.enterText(find.byType(TextFormField).at(2), 'password2');
+      await tester.tap(find.widgetWithText(ElevatedButton, 'Sign Up'));
+      await tester.pump();
+
+      expect(find.text('Passwords do not match'), findsOneWidget);
+    });
+  });
+
+  group('sign in', () {
+    testWidgets('calls onSignInComplete on success', (tester) async {
+      AuthResponse? response;
+      await tester.pumpWidget(
+        buildForm(onSignInComplete: (r) => response = r),
+      );
+
+      await tester.enterText(
+        find.byType(TextFormField).first,
+        'valid@example.com',
+      );
+      await tester.enterText(find.byType(TextFormField).at(1), 'password123');
+      await tester.tap(find.widgetWithText(ElevatedButton, 'Sign In'));
+      await tester.pumpAndSettle();
+
+      expect(response, isNotNull);
+      expect(response!.user, isNotNull);
+      expect(testServer.lastRequest!.url.path, contains('token'));
+      expect(testServer.lastBody['email'], 'valid@example.com');
+    });
+
+    testWidgets('shows an error snack bar when sign in fails', (tester) async {
+      await tester.pumpWidget(buildForm());
+      testServer.responder = (_) =>
+          errorResponse('Invalid login credentials', statusCode: 400);
+
+      await tester.enterText(
+        find.byType(TextFormField).first,
+        'valid@example.com',
+      );
+      await tester.enterText(find.byType(TextFormField).at(1), 'password123');
+      await tester.tap(find.widgetWithText(ElevatedButton, 'Sign In'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Invalid login credentials'), findsOneWidget);
+    });
+
+    testWidgets('forwards the error to onError when provided', (tester) async {
+      Object? captured;
+      await tester.pumpWidget(buildForm(onError: (e) => captured = e));
+      testServer.responder = (_) =>
+          errorResponse('Invalid login credentials', statusCode: 400);
+
+      await tester.enterText(
+        find.byType(TextFormField).first,
+        'valid@example.com',
+      );
+      await tester.enterText(find.byType(TextFormField).at(1), 'password123');
+      await tester.tap(find.widgetWithText(ElevatedButton, 'Sign In'));
+      await tester.pumpAndSettle();
+
+      expect(captured, isA<AuthException>());
+    });
+  });
+
+  group('sign up', () {
+    testWidgets('calls onSignUpComplete on success', (tester) async {
+      AuthResponse? response;
+      await tester.pumpWidget(
+        buildForm(
+          isInitiallySigningIn: false,
+          onSignUpComplete: (r) => response = r,
+        ),
+      );
+
+      await tester.enterText(
+        find.byType(TextFormField).first,
+        'new@example.com',
+      );
+      await tester.enterText(find.byType(TextFormField).at(1), 'password123');
+      await tester.tap(find.widgetWithText(ElevatedButton, 'Sign Up'));
+      await tester.pumpAndSettle();
+
+      expect(response, isNotNull);
+      expect(testServer.lastRequest!.url.path, contains('signup'));
+    });
+
+    testWidgets('sends metadata fields with the sign up request', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildForm(
+          isInitiallySigningIn: false,
+          metadataFields: [
+            MetaDataField(label: 'Username', key: 'username'),
+          ],
+        ),
+      );
+
+      expect(find.text('Username'), findsOneWidget);
+
+      await tester.enterText(
+        find.byType(TextFormField).first,
+        'new@example.com',
+      );
+      await tester.enterText(find.byType(TextFormField).at(1), 'password123');
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Username'),
+        'supauser',
+      );
+      await tester.tap(find.widgetWithText(ElevatedButton, 'Sign Up'));
+      await tester.pumpAndSettle();
+
+      expect(testServer.lastBody['data'], containsPair('username', 'supauser'));
+    });
+
+    testWidgets('blocks sign up until a required checkbox is checked', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildForm(
+          isInitiallySigningIn: false,
+          metadataFields: [
+            BooleanMetaDataField(
+              key: 'terms',
+              label: 'I agree to the terms',
+              isRequired: true,
+            ),
+          ],
+        ),
+      );
+
+      await tester.enterText(
+        find.byType(TextFormField).first,
+        'new@example.com',
+      );
+      await tester.enterText(find.byType(TextFormField).at(1), 'password123');
+      await tester.tap(find.widgetWithText(ElevatedButton, 'Sign Up'));
+      await tester.pump();
+
+      expect(find.text('This field is required'), findsOneWidget);
+      expect(testServer.requests, isEmpty);
+
+      await tester.tap(find.byType(Checkbox));
+      await tester.pump();
+      await tester.tap(find.widgetWithText(ElevatedButton, 'Sign Up'));
+      await tester.pumpAndSettle();
+
+      expect(testServer.lastRequest!.url.path, contains('signup'));
+    });
+  });
+
+  group('password recovery', () {
+    testWidgets('reveals the reset button after tapping forgot password', (
+      tester,
+    ) async {
+      bool? recovering;
+      await tester.pumpWidget(
+        buildForm(onToggleRecoverPassword: (value) => recovering = value),
+      );
+
+      await tester.tap(find.text('Forgot your password?'));
+      await tester.pumpAndSettle();
+
+      expect(recovering, isTrue);
+      expect(
+        find.widgetWithText(ElevatedButton, 'Send password reset email'),
+        findsOneWidget,
+      );
+      expect(find.text('Enter your password'), findsNothing);
+    });
+
+    testWidgets('sends the reset email and reports the address', (
+      tester,
+    ) async {
+      String? resetEmail;
+      await tester.pumpWidget(
+        buildForm(onPasswordResetEmailSent: (email) => resetEmail = email),
+      );
+
+      await tester.tap(find.text('Forgot your password?'));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byType(TextFormField).first,
+        'reset@example.com',
+      );
+      await tester.tap(
+        find.widgetWithText(ElevatedButton, 'Send password reset email'),
+      );
+      await tester.pumpAndSettle();
+
+      expect(resetEmail, 'reset@example.com');
+      expect(testServer.requests.last.url.path, contains('recover'));
+    });
+
+    testWidgets('shows the OTP fields when useOtpForPasswordRecovery is set', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildForm(useOtpForPasswordRecovery: true));
+
+      await tester.tap(find.text('Forgot your password?'));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byType(TextFormField).first,
+        'reset@example.com',
+      );
+      await tester.tap(
+        find.widgetWithText(ElevatedButton, 'Send password reset email'),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Enter OTP code'), findsOneWidget);
+      expect(find.text('Enter new password'), findsOneWidget);
+      expect(
+        find.widgetWithText(ElevatedButton, 'Change Password'),
+        findsOneWidget,
+      );
+    });
+  });
+}

--- a/test/components/supa_magic_auth_test.dart
+++ b/test/components/supa_magic_auth_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_auth_ui/supabase_auth_ui.dart';
+
+import '../test_utils.dart';
+
+void main() {
+  setUpAll(initializeSupabaseForTest);
+  setUp(() => testServer.reset());
+
+  Widget buildForm({
+    void Function(Session session)? onSuccess,
+    void Function(Object error)? onError,
+    bool showSnackBars = true,
+  }) {
+    return wrapForTest(
+      SupaMagicAuth(
+        onSuccess: onSuccess ?? (_) {},
+        onError: onError,
+        showSnackBars: showSnackBars,
+      ),
+    );
+  }
+
+  testWidgets('renders the email field and magic link button', (tester) async {
+    await tester.pumpWidget(buildForm());
+
+    expect(find.text('Enter your email'), findsOneWidget);
+    expect(
+      find.widgetWithText(ElevatedButton, 'Continue with magic Link'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('shows an error for an invalid email', (tester) async {
+    await tester.pumpWidget(buildForm());
+
+    await tester.enterText(find.byType(TextFormField), 'not-an-email');
+    await tester.tap(
+      find.widgetWithText(ElevatedButton, 'Continue with magic Link'),
+    );
+    await tester.pump();
+
+    expect(find.text('Please enter a valid email address'), findsOneWidget);
+    expect(testServer.requests, isEmpty);
+  });
+
+  testWidgets('sends the magic link and shows a confirmation snack bar', (
+    tester,
+  ) async {
+    await tester.pumpWidget(buildForm());
+
+    await tester.enterText(find.byType(TextFormField), 'magic@example.com');
+    await tester.tap(
+      find.widgetWithText(ElevatedButton, 'Continue with magic Link'),
+    );
+    await tester.pumpAndSettle();
+
+    expect(testServer.lastRequest!.url.path, contains('otp'));
+    expect(testServer.lastBody['email'], 'magic@example.com');
+    expect(find.text('Check your email inbox!'), findsOneWidget);
+  });
+
+  testWidgets('shows an error snack bar when the request fails', (
+    tester,
+  ) async {
+    await tester.pumpWidget(buildForm());
+    testServer.responder = (_) => errorResponse('Rate limit exceeded');
+
+    await tester.enterText(find.byType(TextFormField), 'magic@example.com');
+    await tester.tap(
+      find.widgetWithText(ElevatedButton, 'Continue with magic Link'),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Rate limit exceeded'), findsOneWidget);
+  });
+}

--- a/test/components/supa_password_field_test.dart
+++ b/test/components/supa_password_field_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_auth_ui/src/components/supa_password_field.dart';
+
+import '../test_utils.dart';
+
+void main() {
+  testWidgets('obscures the text by default', (tester) async {
+    await tester.pumpWidget(
+      wrapForTest(
+        SupaPasswordField(
+          controller: TextEditingController(),
+          labelText: 'Password',
+        ),
+      ),
+    );
+
+    final field = tester.widget<TextField>(find.byType(TextField));
+    expect(field.obscureText, isTrue);
+    expect(find.byIcon(Icons.visibility_off), findsOneWidget);
+  });
+
+  testWidgets('toggles visibility when the suffix icon is tapped', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      wrapForTest(
+        SupaPasswordField(
+          controller: TextEditingController(),
+          labelText: 'Password',
+        ),
+      ),
+    );
+
+    await tester.tap(find.byIcon(Icons.visibility_off));
+    await tester.pump();
+
+    final field = tester.widget<TextField>(find.byType(TextField));
+    expect(field.obscureText, isFalse);
+    expect(find.byIcon(Icons.visibility), findsOneWidget);
+  });
+
+  testWidgets('runs the provided validator', (tester) async {
+    final formKey = GlobalKey<FormState>();
+    await tester.pumpWidget(
+      wrapForTest(
+        Form(
+          key: formKey,
+          child: SupaPasswordField(
+            controller: TextEditingController(),
+            labelText: 'Password',
+            validator: (value) => 'always invalid',
+          ),
+        ),
+      ),
+    );
+
+    formKey.currentState!.validate();
+    await tester.pump();
+
+    expect(find.text('always invalid'), findsOneWidget);
+  });
+
+  testWidgets('renders the provided label and prefix icon', (tester) async {
+    await tester.pumpWidget(
+      wrapForTest(
+        SupaPasswordField(
+          controller: TextEditingController(),
+          labelText: 'My password',
+          prefixIcon: const Icon(Icons.lock),
+        ),
+      ),
+    );
+
+    expect(find.text('My password'), findsOneWidget);
+    expect(find.byIcon(Icons.lock), findsOneWidget);
+  });
+}

--- a/test/components/supa_phone_auth_test.dart
+++ b/test/components/supa_phone_auth_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_auth_ui/supabase_auth_ui.dart';
+
+import '../test_utils.dart';
+
+void main() {
+  setUpAll(initializeSupabaseForTest);
+  setUp(() => testServer.reset());
+
+  Widget buildForm({
+    required SupaAuthAction authAction,
+    void Function(AuthResponse response)? onSuccess,
+    void Function(Object error)? onError,
+    bool showSnackBars = true,
+  }) {
+    return wrapForTest(
+      SupaPhoneAuth(
+        authAction: authAction,
+        onSuccess: onSuccess ?? (_) {},
+        onError: onError,
+        showSnackBars: showSnackBars,
+      ),
+    );
+  }
+
+  testWidgets('renders phone and password fields with the sign in label', (
+    tester,
+  ) async {
+    await tester.pumpWidget(buildForm(authAction: SupaAuthAction.signIn));
+
+    expect(find.text('Enter your phone number'), findsOneWidget);
+    expect(find.text('Enter your password'), findsOneWidget);
+    expect(find.widgetWithText(ElevatedButton, 'Sign In'), findsOneWidget);
+  });
+
+  testWidgets('shows the sign up label for the sign up action', (tester) async {
+    await tester.pumpWidget(buildForm(authAction: SupaAuthAction.signUp));
+
+    expect(find.widgetWithText(ElevatedButton, 'Sign Up'), findsOneWidget);
+  });
+
+  testWidgets('shows an error for an empty phone number', (tester) async {
+    await tester.pumpWidget(buildForm(authAction: SupaAuthAction.signIn));
+
+    await tester.enterText(find.byType(TextFormField).at(1), 'password123');
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Sign In'));
+    await tester.pump();
+
+    expect(find.text('Please enter a valid phone number'), findsOneWidget);
+    expect(testServer.requests, isEmpty);
+  });
+
+  testWidgets('shows an error for a too short password', (tester) async {
+    await tester.pumpWidget(buildForm(authAction: SupaAuthAction.signIn));
+
+    await tester.enterText(find.byType(TextFormField).first, '+15551234567');
+    await tester.enterText(find.byType(TextFormField).at(1), '123');
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Sign In'));
+    await tester.pump();
+
+    expect(
+      find.text('Please enter a password that is at least 6 characters long'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('signs in with phone and password and reports success', (
+    tester,
+  ) async {
+    AuthResponse? response;
+    await tester.pumpWidget(
+      buildForm(
+        authAction: SupaAuthAction.signIn,
+        onSuccess: (r) => response = r,
+      ),
+    );
+
+    await tester.enterText(find.byType(TextFormField).first, '+15551234567');
+    await tester.enterText(find.byType(TextFormField).at(1), 'password123');
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Sign In'));
+    await tester.pumpAndSettle();
+
+    expect(response, isNotNull);
+    expect(testServer.lastBody['phone'], '+15551234567');
+  });
+
+  testWidgets('signs up with phone and password', (tester) async {
+    AuthResponse? response;
+    await tester.pumpWidget(
+      buildForm(
+        authAction: SupaAuthAction.signUp,
+        onSuccess: (r) => response = r,
+      ),
+    );
+
+    await tester.enterText(find.byType(TextFormField).first, '+15551234567');
+    await tester.enterText(find.byType(TextFormField).at(1), 'password123');
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Sign Up'));
+    await tester.pumpAndSettle();
+
+    expect(response, isNotNull);
+    expect(testServer.lastRequest!.url.path, contains('signup'));
+  });
+
+  testWidgets('shows an error snack bar when the request fails', (
+    tester,
+  ) async {
+    await tester.pumpWidget(buildForm(authAction: SupaAuthAction.signIn));
+    testServer.responder = (_) => errorResponse('Invalid phone or password');
+
+    await tester.enterText(find.byType(TextFormField).first, '+15551234567');
+    await tester.enterText(find.byType(TextFormField).at(1), 'password123');
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Sign In'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Invalid phone or password'), findsOneWidget);
+  });
+}

--- a/test/components/supa_reset_password_test.dart
+++ b/test/components/supa_reset_password_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_auth_ui/supabase_auth_ui.dart';
+
+import '../test_utils.dart';
+
+void main() {
+  setUpAll(initializeSupabaseForTest);
+  setUp(() => testServer.reset());
+  tearDown(signOutTestUser);
+
+  Widget buildForm({
+    void Function(UserResponse response)? onSuccess,
+    void Function(Object error)? onError,
+    bool showSnackBars = true,
+  }) {
+    return wrapForTest(
+      SupaResetPassword(
+        onSuccess: onSuccess ?? (_) {},
+        onError: onError,
+        showSnackBars: showSnackBars,
+      ),
+    );
+  }
+
+  testWidgets('renders the password field and update button', (tester) async {
+    await tester.pumpWidget(buildForm());
+
+    expect(find.text('Enter your password'), findsOneWidget);
+    expect(
+      find.widgetWithText(ElevatedButton, 'Update Password'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('shows an error for a too short password', (tester) async {
+    await tester.pumpWidget(buildForm());
+
+    await tester.enterText(find.byType(TextFormField), '123');
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Update Password'));
+    await tester.pump();
+
+    expect(
+      find.text('Please enter a password that is at least 6 characters long'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('updates the password and reports success', (tester) async {
+    await signInTestUser();
+    UserResponse? response;
+    await tester.pumpWidget(buildForm(onSuccess: (r) => response = r));
+
+    await tester.enterText(find.byType(TextFormField), 'newpassword');
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Update Password'));
+    await tester.pumpAndSettle();
+
+    expect(response, isNotNull);
+    expect(testServer.lastRequest!.method, 'PUT');
+    expect(testServer.lastRequest!.url.path, endsWith('/user'));
+    expect(find.text('Password reset email has been sent'), findsOneWidget);
+  });
+
+  testWidgets('forwards an error to onError when the update fails', (
+    tester,
+  ) async {
+    await signInTestUser();
+    Object? captured;
+    await tester.pumpWidget(buildForm(onError: (e) => captured = e));
+    testServer.responder = (_) => errorResponse('Update failed');
+
+    await tester.enterText(find.byType(TextFormField), 'newpassword');
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Update Password'));
+    await tester.pumpAndSettle();
+
+    expect(captured, isA<AuthException>());
+  });
+}

--- a/test/components/supa_socials_auth_test.dart
+++ b/test/components/supa_socials_auth_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_auth_ui/supabase_auth_ui.dart';
+
+import '../test_utils.dart';
+
+void main() {
+  setUpAll(initializeSupabaseForTest);
+  setUp(() => testServer.reset());
+
+  testWidgets('shows an ErrorWidget when the provider list is empty', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      wrapForTest(
+        SupaSocialsAuth(socialProviders: const [], onSuccess: (_) {}),
+      ),
+    );
+
+    expect(find.byType(ErrorWidget), findsOneWidget);
+  });
+
+  testWidgets('renders a labelled button per provider in iconAndText mode', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      wrapForTest(
+        SupaSocialsAuth(
+          socialProviders: const [
+            OAuthProvider.github,
+            OAuthProvider.google,
+          ],
+          onSuccess: (_) {},
+        ),
+      ),
+    );
+
+    expect(find.text('Continue with Github'), findsOneWidget);
+    expect(find.text('Continue with Google'), findsOneWidget);
+    expect(find.byType(ElevatedButton), findsNWidgets(2));
+  });
+
+  testWidgets('renders icon-only buttons without labels in icon mode', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      wrapForTest(
+        SupaSocialsAuth(
+          socialProviders: const [OAuthProvider.github],
+          socialButtonVariant: SocialButtonVariant.icon,
+          onSuccess: (_) {},
+        ),
+      ),
+    );
+
+    expect(find.text('Continue with Github'), findsNothing);
+    expect(find.byType(ElevatedButton), findsNothing);
+    expect(find.byType(InkResponse), findsOneWidget);
+  });
+
+  testWidgets('uses a custom label from localization when provided', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      wrapForTest(
+        SupaSocialsAuth(
+          socialProviders: const [OAuthProvider.azure],
+          localization: SupaSocialsAuthLocalization(
+            oAuthButtonLabels: {OAuthProvider.azure: 'Microsoft (Azure)'},
+          ),
+          onSuccess: (_) {},
+        ),
+      ),
+    );
+
+    expect(find.text('Microsoft (Azure)'), findsOneWidget);
+  });
+}

--- a/test/components/supa_socials_auth_test.dart
+++ b/test/components/supa_socials_auth_test.dart
@@ -37,7 +37,12 @@ void main() {
 
     expect(find.text('Continue with Github'), findsOneWidget);
     expect(find.text('Continue with Google'), findsOneWidget);
-    expect(find.byType(ElevatedButton), findsNWidgets(2));
+    // `ElevatedButton.icon` returns an `ElevatedButton` subclass on some
+    // Flutter versions, which `find.byType` would miss, so match by predicate.
+    expect(
+      find.byWidgetPredicate((widget) => widget is ElevatedButton),
+      findsNWidgets(2),
+    );
   });
 
   testWidgets('renders icon-only buttons without labels in icon mode', (
@@ -54,7 +59,10 @@ void main() {
     );
 
     expect(find.text('Continue with Github'), findsNothing);
-    expect(find.byType(ElevatedButton), findsNothing);
+    expect(
+      find.byWidgetPredicate((widget) => widget is ElevatedButton),
+      findsNothing,
+    );
     expect(find.byType(InkResponse), findsOneWidget);
   });
 

--- a/test/components/supa_verify_phone_test.dart
+++ b/test/components/supa_verify_phone_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_auth_ui/supabase_auth_ui.dart';
+
+import '../test_utils.dart';
+
+void main() {
+  setUpAll(initializeSupabaseForTest);
+  setUp(() => testServer.reset());
+
+  testWidgets('renders the code field and verify button', (tester) async {
+    await tester.pumpWidget(
+      wrapWithRouteArguments(
+        SupaVerifyPhone(onSuccess: (_) {}),
+        {'phone': '+15551234567'},
+      ),
+    );
+
+    expect(find.text('Enter the code sent'), findsOneWidget);
+    expect(
+      find.widgetWithText(ElevatedButton, 'Verify Phone'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('shows an error when the code is empty', (tester) async {
+    await tester.pumpWidget(
+      wrapWithRouteArguments(
+        SupaVerifyPhone(onSuccess: (_) {}),
+        {'phone': '+15551234567'},
+      ),
+    );
+
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Verify Phone'));
+    await tester.pump();
+
+    expect(
+      find.text('Please enter the one time code sent'),
+      findsOneWidget,
+    );
+    expect(testServer.requests, isEmpty);
+  });
+
+  testWidgets('verifies the OTP and reports success', (tester) async {
+    AuthResponse? response;
+    await tester.pumpWidget(
+      wrapWithRouteArguments(
+        SupaVerifyPhone(onSuccess: (r) => response = r),
+        {'phone': '+15551234567'},
+      ),
+    );
+
+    await tester.enterText(find.byType(TextFormField), '123456');
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Verify Phone'));
+    await tester.pumpAndSettle();
+
+    expect(response, isNotNull);
+    expect(testServer.lastRequest!.url.path, contains('verify'));
+    expect(testServer.lastBody['phone'], '+15551234567');
+    expect(testServer.lastBody['token'], '123456');
+  });
+
+  testWidgets('clears the code field after verifying', (tester) async {
+    await tester.pumpWidget(
+      wrapWithRouteArguments(
+        SupaVerifyPhone(onSuccess: (_) {}),
+        {'phone': '+15551234567'},
+      ),
+    );
+
+    await tester.enterText(find.byType(TextFormField), '123456');
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Verify Phone'));
+    await tester.pumpAndSettle();
+
+    final field = tester.widget<TextField>(find.byType(TextField));
+    expect(field.controller!.text, isEmpty);
+  });
+
+  testWidgets('shows an error snack bar when verification fails', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      wrapWithRouteArguments(
+        SupaVerifyPhone(onSuccess: (_) {}),
+        {'phone': '+15551234567'},
+      ),
+    );
+    testServer.responder = (_) => errorResponse('Token has expired');
+
+    await tester.enterText(find.byType(TextFormField), '123456');
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Verify Phone'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Token has expired'), findsOneWidget);
+  });
+}

--- a/test/localizations_test.dart
+++ b/test/localizations_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_auth_ui/supabase_auth_ui.dart';
+
+void main() {
+  test('SupaEmailAuthLocalization exposes sensible defaults', () {
+    const localization = SupaEmailAuthLocalization();
+
+    expect(localization.enterEmail, 'Enter your email');
+    expect(localization.signIn, 'Sign In');
+    expect(localization.signUp, 'Sign Up');
+    expect(localization.confirmPasswordError, 'Passwords do not match');
+  });
+
+  test('SupaEmailAuthLocalization values can be overridden', () {
+    const localization = SupaEmailAuthLocalization(
+      signIn: 'Connexion',
+      signUp: 'Inscription',
+    );
+
+    expect(localization.signIn, 'Connexion');
+    expect(localization.signUp, 'Inscription');
+    expect(localization.enterEmail, 'Enter your email');
+  });
+
+  test('SupaMagicAuthLocalization exposes sensible defaults', () {
+    const localization = SupaMagicAuthLocalization();
+
+    expect(localization.continueWithMagicLink, 'Continue with magic Link');
+    expect(localization.checkYourEmail, 'Check your email inbox!');
+  });
+
+  test('SupaPhoneAuthLocalization exposes sensible defaults', () {
+    const localization = SupaPhoneAuthLocalization();
+
+    expect(localization.enterPhoneNumber, 'Enter your phone number');
+    expect(
+      localization.validPhoneNumberError,
+      'Please enter a valid phone number',
+    );
+  });
+
+  test('SupaResetPasswordLocalization exposes sensible defaults', () {
+    const localization = SupaResetPasswordLocalization();
+
+    expect(localization.updatePassword, 'Update Password');
+  });
+
+  test('SupaVerifyPhoneLocalization exposes sensible defaults', () {
+    const localization = SupaVerifyPhoneLocalization();
+
+    expect(localization.verifyPhone, 'Verify Phone');
+    expect(localization.enterCodeSent, 'Enter the code sent');
+  });
+
+  test('SupaSocialsAuthLocalization defaults to an empty label map', () {
+    const localization = SupaSocialsAuthLocalization();
+
+    expect(localization.successSignInMessage, 'Successfully signed in!');
+    expect(localization.oAuthButtonLabels, isEmpty);
+  });
+}

--- a/test/supa_flutter_auth_test.dart
+++ b/test/supa_flutter_auth_test.dart
@@ -1,5 +1,0 @@
-import 'package:flutter_test/flutter_test.dart';
-
-void main() {
-  test('adds one to input values', () {});
-}

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -1,0 +1,195 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:supabase_auth_ui/supabase_auth_ui.dart';
+
+/// In-memory implementation of [GotrueAsyncStorage] so the PKCE storage never
+/// reaches for shared preferences during tests.
+class _InMemoryAsyncStorage extends GotrueAsyncStorage {
+  final _store = <String, String>{};
+
+  @override
+  Future<String?> getItem({required String key}) async => _store[key];
+
+  @override
+  Future<void> setItem({required String key, required String value}) async {
+    _store[key] = value;
+  }
+
+  @override
+  Future<void> removeItem({required String key}) async {
+    _store.remove(key);
+  }
+}
+
+/// Signature for a function that turns an intercepted request into a response.
+typedef MockResponder = http.Response Function(http.Request request);
+
+/// Records every request the Supabase client makes and lets each test swap in
+/// the response it wants to assert against.
+class SupabaseTestServer {
+  SupabaseTestServer();
+
+  final List<http.Request> requests = [];
+
+  /// The responder used for the next requests. Defaults to returning a valid
+  /// session for any auth endpoint.
+  MockResponder responder = defaultResponder;
+
+  http.Client get client => MockClient((request) async {
+    requests.add(request);
+    return responder(request);
+  });
+
+  void reset() {
+    requests.clear();
+    responder = defaultResponder;
+  }
+
+  http.Request? get lastRequest => requests.isEmpty ? null : requests.last;
+
+  /// Returns the parsed JSON body of the last request, or `{}` when there was
+  /// no body.
+  Map<String, dynamic> get lastBody {
+    final body = lastRequest?.body ?? '';
+    if (body.isEmpty) return {};
+    return jsonDecode(body) as Map<String, dynamic>;
+  }
+}
+
+const _fakeUser = {
+  'id': '11111111-1111-1111-1111-111111111111',
+  'aud': 'authenticated',
+  'role': 'authenticated',
+  'email': 'test@example.com',
+  'app_metadata': {'provider': 'email'},
+  'user_metadata': <String, dynamic>{},
+  'created_at': '2024-01-01T00:00:00.000Z',
+  'is_anonymous': false,
+};
+
+final _fakeSession = {
+  'access_token': 'fake-access-token',
+  'token_type': 'bearer',
+  'expires_in': 3600,
+  'refresh_token': 'fake-refresh-token',
+  'user': _fakeUser,
+};
+
+/// Builds a success response with a full session for any auth endpoint.
+http.Response sessionResponse() => http.Response(
+  jsonEncode(_fakeSession),
+  200,
+  headers: {'content-type': 'application/json'},
+);
+
+/// Builds a success response containing just a user (no session).
+http.Response userResponse() => http.Response(
+  jsonEncode(_fakeUser),
+  200,
+  headers: {'content-type': 'application/json'},
+);
+
+/// Builds an error response that gotrue parses into an [AuthApiException].
+http.Response errorResponse(
+  String message, {
+  int statusCode = 400,
+  String? code,
+}) => http.Response(
+  jsonEncode({
+    'message': message,
+    if (code != null) 'error_code': code,
+  }),
+  statusCode,
+  headers: {'content-type': 'application/json'},
+);
+
+/// Default responder used between tests.
+///
+/// `recover` and `otp` endpoints return an empty body, everything else returns
+/// a session.
+http.Response defaultResponder(http.Request request) {
+  final path = request.url.path;
+  if (path.endsWith('/recover') || path.endsWith('/otp')) {
+    return http.Response(
+      '{}',
+      200,
+      headers: {'content-type': 'application/json'},
+    );
+  }
+  if (path.endsWith('/user') && request.method == 'GET') {
+    return userResponse();
+  }
+  return sessionResponse();
+}
+
+/// Shared server instance for the running test isolate.
+late final SupabaseTestServer testServer;
+
+/// Initializes Supabase once per test isolate, wiring up the mock HTTP client
+/// and in-memory storage so no real network or platform calls are made.
+Future<void> initializeSupabaseForTest() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  testServer = SupabaseTestServer();
+  await Supabase.initialize(
+    url: 'http://localhost:54321',
+    publishableKey: 'test-anon-key',
+    debug: false,
+    httpClient: testServer.client,
+    authOptions: FlutterAuthClientOptions(
+      localStorage: const EmptyLocalStorage(),
+      pkceAsyncStorage: _InMemoryAsyncStorage(),
+      detectSessionInUri: false,
+      autoRefreshToken: false,
+    ),
+  );
+}
+
+/// Wraps [child] in a minimal [MaterialApp] so it has the inherited widgets it
+/// needs (theme, directionality, scaffold for snack bars).
+Widget wrapForTest(Widget child) {
+  return MaterialApp(
+    home: Scaffold(
+      body: SingleChildScrollView(child: child),
+    ),
+  );
+}
+
+/// Like [wrapForTest] but exposes [arguments] through the route so widgets that
+/// read `ModalRoute.of(context)?.settings.arguments` receive them.
+Widget wrapWithRouteArguments(Widget child, Object? arguments) {
+  return MaterialApp(
+    onGenerateRoute: (settings) => MaterialPageRoute(
+      settings: RouteSettings(name: settings.name, arguments: arguments),
+      builder: (_) => Scaffold(
+        body: SingleChildScrollView(child: child),
+      ),
+    ),
+  );
+}
+
+/// Signs a fake user in so endpoints that require an active session (such as
+/// `updateUser`) succeed. Call [signOutTestUser] afterwards to clean up.
+Future<void> signInTestUser() async {
+  testServer.responder = (_) => sessionResponse();
+  await Supabase.instance.client.auth.signInWithPassword(
+    email: 'test@example.com',
+    password: 'password123',
+  );
+}
+
+/// Clears the current session so it does not leak into the next test.
+///
+/// Restores the default responder first so the sign-out request is not tripped
+/// up by a responder a test swapped in to simulate a failure.
+Future<void> signOutTestUser() async {
+  testServer.responder = defaultResponder;
+  try {
+    await Supabase.instance.client.auth.signOut(scope: SignOutScope.local);
+  } catch (_) {
+    // The session may already be gone; nothing else to clean up.
+  }
+}

--- a/test/utils/constants_test.dart
+++ b/test/utils/constants_test.dart
@@ -1,0 +1,208 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_auth_ui/src/utils/constants.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+void main() {
+  group('defaultPasswordValidator', () {
+    final validate = defaultPasswordValidator('too short');
+
+    test('returns the error for a null value', () {
+      expect(validate(null), 'too short');
+    });
+
+    test('returns the error for an empty value', () {
+      expect(validate(''), 'too short');
+    });
+
+    test('returns the error for a value shorter than 6 characters', () {
+      expect(validate('12345'), 'too short');
+    });
+
+    test('returns null for a value with exactly 6 characters', () {
+      expect(validate('123456'), isNull);
+    });
+
+    test('returns null for a value longer than 6 characters', () {
+      expect(validate('1234567'), isNull);
+    });
+  });
+
+  group('handleAuthError', () {
+    testWidgets('calls onError when provided and never shows a snack bar', (
+      tester,
+    ) async {
+      Object? captured;
+      late BuildContext capturedContext;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) {
+                capturedContext = context;
+                return const SizedBox();
+              },
+            ),
+          ),
+        ),
+      );
+
+      final error = Exception('boom');
+      handleAuthError(
+        capturedContext,
+        error,
+        onError: (e) => captured = e,
+        showSnackBars: true,
+        unexpectedErrorText: 'Unexpected',
+      );
+      await tester.pump();
+
+      expect(captured, error);
+      expect(find.byType(SnackBar), findsNothing);
+    });
+
+    testWidgets('shows the message of an AuthException in a snack bar', (
+      tester,
+    ) async {
+      late BuildContext capturedContext;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) {
+                capturedContext = context;
+                return const SizedBox();
+              },
+            ),
+          ),
+        ),
+      );
+
+      handleAuthError(
+        capturedContext,
+        const AuthException('Invalid credentials'),
+        onError: null,
+        showSnackBars: true,
+        unexpectedErrorText: 'Unexpected',
+      );
+      await tester.pump();
+
+      expect(find.text('Invalid credentials'), findsOneWidget);
+    });
+
+    testWidgets('prefixes non-auth errors with the unexpected error text', (
+      tester,
+    ) async {
+      late BuildContext capturedContext;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) {
+                capturedContext = context;
+                return const SizedBox();
+              },
+            ),
+          ),
+        ),
+      );
+
+      handleAuthError(
+        capturedContext,
+        'plain error',
+        onError: null,
+        showSnackBars: true,
+        unexpectedErrorText: 'Unexpected',
+      );
+      await tester.pump();
+
+      expect(find.text('Unexpected: plain error'), findsOneWidget);
+    });
+
+    testWidgets('does not show a snack bar when showSnackBars is false', (
+      tester,
+    ) async {
+      late BuildContext capturedContext;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) {
+                capturedContext = context;
+                return const SizedBox();
+              },
+            ),
+          ),
+        ),
+      );
+
+      handleAuthError(
+        capturedContext,
+        const AuthException('Invalid credentials'),
+        onError: null,
+        showSnackBars: false,
+        unexpectedErrorText: 'Unexpected',
+      );
+      await tester.pump();
+
+      expect(find.byType(SnackBar), findsNothing);
+    });
+  });
+
+  group('ShowSnackBar extension', () {
+    testWidgets('showSnackBar displays the message with a default action', (
+      tester,
+    ) async {
+      late BuildContext capturedContext;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) {
+                capturedContext = context;
+                return const SizedBox();
+              },
+            ),
+          ),
+        ),
+      );
+
+      capturedContext.showSnackBar('Hello');
+      await tester.pump();
+
+      expect(find.text('Hello'), findsOneWidget);
+      expect(find.text('ok'), findsOneWidget);
+    });
+
+    testWidgets('showErrorSnackBar uses the error container colors', (
+      tester,
+    ) async {
+      late BuildContext capturedContext;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) {
+                capturedContext = context;
+                return const SizedBox();
+              },
+            ),
+          ),
+        ),
+      );
+
+      capturedContext.showErrorSnackBar('Bad');
+      await tester.pump();
+
+      final snackBar = tester.widget<SnackBar>(find.byType(SnackBar));
+      final theme = Theme.of(capturedContext);
+      expect(snackBar.backgroundColor, theme.colorScheme.errorContainer);
+    });
+  });
+
+  test('spacer returns a SizedBox of the given height', () {
+    final box = spacer(24);
+    expect(box.height, 24);
+  });
+}

--- a/test/utils/supa_auth_action_test.dart
+++ b/test/utils/supa_auth_action_test.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_auth_ui/supabase_auth_ui.dart';
+
+void main() {
+  test('SupaAuthAction has signIn and signUp values', () {
+    expect(SupaAuthAction.values, [
+      SupaAuthAction.signIn,
+      SupaAuthAction.signUp,
+    ]);
+  });
+}


### PR DESCRIPTION
## What

Replaces the placeholder test with a full unit and widget test suite (72 tests) covering every component, localization, and utility in the package.

## Test harness

A shared harness (`test/test_utils.dart`) wires a `MockClient` into `Supabase.initialize` so the widgets can be exercised without any real network or platform plugins:
- Records every request and lets each test swap in a responder (success session, user-only, or error).
- Uses `EmptyLocalStorage`, an in-memory PKCE store, and `detectSessionInUri: false` so no plugins are touched.
- Helpers for route arguments (`SupaVerifyPhone`), establishing/clearing a session, and building responses.

## Coverage

- **Utilities**: `defaultPasswordValidator`, `handleAuthError`, snackbar extensions, `spacer`, `SupaAuthAction`.
- **Localizations**: defaults and overrides for all six localization classes.
- **Metadata fields**: `MetaDataField` / `BooleanMetaDataField` (defaults, assertion, rich/plain label rendering).
- **Components**: `SupaEmailAuth` (rendering, validation, sign in/up, metadata, required-checkbox gating, password recovery + OTP flows), `SupaMagicAuth`, `SupaResetPassword`, `SupaPhoneAuth`, `SupaVerifyPhone`, `SupaSocialsAuth`, `SupaPasswordField`.

## Other

- Added `http` to `dev_dependencies` (used by the harness).
- Added `test` to the melos `analyze` script so test code is linted in CI.

All tests pass and `flutter analyze --fatal-warnings --fatal-infos` and `dart format` are clean.